### PR TITLE
[COOK-1939] Change restart by reload

### DIFF
--- a/recipes/app_lb.rb
+++ b/recipes/app_lb.rb
@@ -58,7 +58,7 @@ template "/etc/haproxy/haproxy.cfg" do
   group "root"
   mode 00644
   variables :pool_members => pool_members.uniq
-  notifies :restart, "service[haproxy]"
+  notifies :reload, "service[haproxy]"
 end
 
 service "haproxy" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,7 +34,7 @@ template "/etc/haproxy/haproxy.cfg" do
   owner "root"
   group "root"
   mode 00644
-  notifies :restart, "service[haproxy]"
+  notifies :reload, "service[haproxy]"
 end
 
 service "haproxy" do


### PR DESCRIPTION
haproxy must't be restart, it manage too much connections

http://tickets.opscode.com/browse/COOK-1939
