### PR TITLE
COOK-2270: Made 'app_lb' config template dynamic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Attributes
   config, set the the maxconn per frontend member
 * `node['haproxy']['frontend_ssl_max_connections']` - in the `app_lb`
   config, set the maxconn per frontend member using SSL
+* `node['haproxy']['app_lb_source']` - specify your own `app_lb` config file.
+* `node['haproxy']['app_lb_cookbook']` - specify the cookbook for your custom
+  `app_lb` conf file.
 
 Recipes
 =======

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,3 +46,6 @@ default['haproxy']['global_max_connections'] = 4096
 default['haproxy']['member_max_connections'] = 100
 default['haproxy']['frontend_max_connections'] = 2000
 default['haproxy']['frontend_ssl_max_connections'] = 2000
+
+default['haproxy']['app_lb_source'] = "haproxy-app_lb.cfg.erb"
+default['haproxy']['app_lb_cookbook'] = nil

--- a/recipes/app_lb.rb
+++ b/recipes/app_lb.rb
@@ -53,7 +53,10 @@ cookbook_file "/etc/default/haproxy" do
 end
 
 template "/etc/haproxy/haproxy.cfg" do
-  source "haproxy-app_lb.cfg.erb"
+  source node['haproxy']['app_lb_source']
+  if node['haproxy']['app_lb_cookbook']
+    cookbook node['haproxy']['app_lb_cookbook']
+  end
   owner "root"
   group "root"
   mode 00644


### PR DESCRIPTION
Added option to specify a custom 'app_lb' config file and a corresponding cookbook.

With this option you can have multiple haproxy configurations within one organisation.
