### PR TITLE
[COOK-3188] Allow setting of conf_dir attribute when using the default package install

### DIFF
--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -21,3 +21,17 @@ package "haproxy" do
   action :install
 end
 
+directory node['haproxy']['conf_dir']
+
+template "/etc/init.d/haproxy" do
+  source "haproxy-init.erb"
+  owner "root"
+  group "root"
+  mode 00755
+  variables(
+    :hostname => node['hostname'],
+    :conf_dir => node['haproxy']['conf_dir'],
+    :prefix => "/usr"
+  )
+end
+


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3188
