### PR TITLE
Add 'use_openssl' attribute for when installing HAProxy from source.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,3 +59,4 @@ default['haproxy']['source']['target_cpu'] = ''
 default['haproxy']['source']['target_arch'] = ''
 default['haproxy']['source']['use_pcre'] = false
 default['haproxy']['source']['use_openssl'] = false
+default['haproxy']['source']['use_zlib'] = false

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -32,6 +32,7 @@ make_cmd << " CPU=#{node['haproxy']['source']['target_cpu' ]}" unless node['hapr
 make_cmd << " ARCH=#{node['haproxy']['source']['target_arch']}" unless node['haproxy']['source']['target_arch'].empty?
 make_cmd << " USE_PCRE=1" if node['haproxy']['source']['use_pcre']
 make_cmd << " USE_OPENSSL=1" if node['haproxy']['source']['use_openssl']
+make_cmd << " USE_ZLIB=1" if node['haproxy']['source']['use_zlib']
 
 bash "compile_haproxy" do
   cwd Chef::Config[:file_cache_path]


### PR DESCRIPTION
Hello!

To be able to use haproxy's SSL support HAProxy needs to be compiled with `USE_OPENSSL=1` (from the README in the haproxy tarball).

This adds a default `use_openssl` attribute and changes the `make` command in `install_source.rb` to add the `USE_OPENSSL=1` flag when the `use_openssl` attribute is true.
The default for `use_openssl` is `false`.
