### PR TITLE
[COOK-3425] Berkshelf dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'test-kitchen', '~> 1.0.0.beta.2'
+gem 'kitchen-vagrant', :group => :integration
+gem 'berkshelf'


### PR DESCRIPTION
Since we're requiring Berkshelf to use Test Kitchen let's `bundle` it.
