### PR TITLE
[COOK-3537] OpenSSL and zlib HAProxy source configurations

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,3 +61,5 @@ default['haproxy']['source']['target_os'] = 'generic'
 default['haproxy']['source']['target_cpu'] = ''
 default['haproxy']['source']['target_arch'] = ''
 default['haproxy']['source']['use_pcre'] = false
+default['haproxy']['source']['use_openssl'] = false
+default['haproxy']['source']['use_zlib'] = false

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -19,6 +19,30 @@
 
 include_recipe 'build-essential'
 
+package 'libpcre3-dev' do
+  case node[:platform]
+  when 'debian', 'ubuntu'
+    package_name 'libpcre3-dev'
+  end
+  only_if { node['haproxy']['source']['use_pcre'] }
+end
+
+package 'libssl-dev' do
+  case node[:platform]
+  when 'debian', 'ubuntu'
+    package_name 'libssl-dev'
+  end
+  only_if { node['haproxy']['source']['use_openssl'] }
+end
+
+package 'zlib1g-dev' do
+  case node[:platform]
+  when 'debian', 'ubuntu'
+    package_name 'zlib1g-dev'
+  end
+  only_if { node['haproxy']['source']['use_zlib'] }
+end
+
 node.set['haproxy']['conf_dir'] = "#{node['haproxy']['source']['prefix']}/etc"
 
 remote_file "#{Chef::Config[:file_cache_path]}/haproxy-#{node['haproxy']['source']['version']}.tar.gz" do
@@ -31,6 +55,8 @@ make_cmd = "make TARGET=#{node['haproxy']['source']['target_os']}"
 make_cmd << " CPU=#{node['haproxy']['source']['target_cpu' ]}" unless node['haproxy']['source']['target_cpu'].empty?
 make_cmd << " ARCH=#{node['haproxy']['source']['target_arch']}" unless node['haproxy']['source']['target_arch'].empty?
 make_cmd << " USE_PCRE=1" if node['haproxy']['source']['use_pcre']
+make_cmd << " USE_OPENSSL=1" if node['haproxy']['source']['use_openssl']
+make_cmd << " USE_ZLIB=1" if node['haproxy']['source']['use_zlib']
 
 bash "compile_haproxy" do
   cwd Chef::Config[:file_cache_path]


### PR DESCRIPTION
Being able to configure HAProxy source build with OpenSSL and zlib is nice. Also, let's make sure PCRE dependencies are met if that option is enabled.

http://tickets.opscode.com/browse/COOK-3537
