### PR TITLE
[COOK-3424] haproxy_defaults_options method tries to update Chef::Node::ImmutableArray if node['haproxy']['x_forwarded_for'] is set

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -3,7 +3,6 @@ def haproxy_defaults_options
   if node['haproxy']['x_forwarded_for']
     options.push("forwardfor")
   end
-
   return options.uniq
 end
 


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3424

Looks like  if node['haproxy']['x_forwarded_for'] is set, an operation is applied to it that is illegal now that the node['haproxy']['x_forwarded_for'] attribute is a Chef::Node::ImmutableArray. This fix changes an assignment: 

```
options = node['haproxy']['defaults_options']
```

to

```
options = node['haproxy']['defaults_options'].dup
```

(dup's the node['haproxy']['defaults_options'] into a normal array which can then be properly used as in:

```
options.push("forwardfor")
```

I could not see anyplace in the code where it expected node['haproxy']['x_forwarded_for'] to be actullly updated by this method, just that the result of the method has the merge of node['haproxy']['x_forwarded_for'] with 
