### PR TITLE
Update to Chef 11 style node attributes

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,5 +1,5 @@
 def haproxy_defaults_options
-  options = node['haproxy']['defaults_options']
+  options = node.default['haproxy']['defaults_options']
   if node['haproxy']['x_forwarded_for']
     options.push("forwardfor")
   end


### PR DESCRIPTION
Original recipe errors out on Chef 11. Need to specify a precedence when writing node attributes.
