### PR TITLE
fixed issue where 'servers' var was not being set to string correctly

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,6 +43,7 @@ default['haproxy']['ssl_member_port'] = 8443
 default['haproxy']['enable_mysql'] = false
 default['haproxy']['mysql_incoming_port'] = 3306
 default['haproxy']['mysql_incoming_address'] = "0.0.0.0"
+default['haproxy']['mysql_check_user'] = 'root'
 
 default['haproxy']['httpchk'] = nil
 default['haproxy']['ssl_httpchk'] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -104,7 +104,7 @@ if node['haproxy']['enable_mysql']
     balance 'roundrobin'
     servers servers
     params([
-      "option mysql-check user root"
+      "option mysql-check user #{conf['mysql_check_user']}"
     ])
   end
 end


### PR DESCRIPTION
The `servers` var was being set to the result of an `each` which makes the server var have the wrong result.  Changing to `map` gets the variable assigned correctly. 
