### PR TITLE
Only call use_inline_resources if it's available

### DIFF
--- a/providers/lb.rb
+++ b/providers/lb.rb
@@ -1,4 +1,4 @@
-use_inline_resources
+use_inline_resources if defined?(use_inline_resources)
 
 action :create do
   #While there is no way to have an include directive for haproxy


### PR DESCRIPTION
As noted in https://github.com/opscode-cookbooks/ark/pull/25 and https://github.com/opscode-cookbooks/apt/pull/53 you can only use `use_inline_resources` in certain versions of chef.  This provides the same fix to continue to support older versions.
