### PR TITLE
Provide some flexibility around the global / defaults stanzas

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,6 +65,16 @@ default['haproxy']['member_max_connections'] = 100
 default['haproxy']['frontend_max_connections'] = 2000
 default['haproxy']['frontend_ssl_max_connections'] = 2000
 
+default['haproxy']['global_logs'] = [
+  {:address => '127.0.0.1', :facility => 'local0'},
+  {:address => '127.0.0.1', :facility => 'local1', :max => 'notice'}
+]
+default['haproxy']['global_mode'] = "http"
+default['haproxy']['global_retries'] = 3
+
+default['haproxy']['global_listener'] = []
+default['haproxy']['defaults_listener'] = []
+
 default['haproxy']['install_method'] = 'package'
 default['haproxy']['conf_dir'] = '/etc/haproxy'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -169,6 +169,37 @@ attribute "haproxy/frontend_ssl_max_connections",
   :required => "optional",
   :default => "2000"
 
+attribute "haproxy/global_logs",
+  :display_name => "HAProxy global syslog servers",
+  :description => "Syslog server configurations in the global stanza.",
+  :required => "optional",
+  :default => [
+    {:address => '127.0.0.1', :facility => 'local0'},
+    {:address => '127.0.0.1', :facility => 'local1', :max => 'notice'}
+  ]
+
+attribute "haproxy/global_mode",
+  :display_name => "HAProxy global running mode / protocol",
+  :description => "Running mode / protocol in the global stanza.",
+  :required => "optional",
+  :default => "http"
+
+attribute "haproxy/global_retries",
+  :display_name => "HAProxy global connection attempts",
+  :description => "Maximum number of connection attempts in the global stanza.",
+  :required => "optional",
+  :default => "3"
+
+attribute "haproxy/global_listener",
+  :display_name => "HAProxy global configuration options",
+  :description => "Additional, open-ended configuration options for the global stanza.",
+  :required => "optional"
+
+attribute "haproxy/defaults_listener",
+  :display_name => "HAProxy defaults configuration options",
+  :description => "Additional, open-ended configuration options for the defaults stanza.",
+  :required => "optional"
+
 attribute "haproxy/install_method",
   :display_name => "HAProxy install method",
   :description => "Determines which method is used to install haproxy, must be 'source' or 'package'. defaults to 'package'.",

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -1,20 +1,21 @@
 global
-  log 127.0.0.1   local0
-  log 127.0.0.1   local1 notice
-  #log loghost    local0 info
+<% node['haproxy']['global_logs'].each do |log| -%>
+  log <%= log['address'] %> <%= log['facility'] %> <%= log['max'] %> <%= log['min'] %>
+<% end -%>
   maxconn <%= node['haproxy']['global_max_connections'] %>
-  #debug
-  #quiet
   user <%= node['haproxy']['user'] %>
   group <%= node['haproxy']['group'] %>
 <% if node['haproxy']['enable_stats_socket'] -%>
   stats socket <%= node['haproxy']['stats_socket_path'] %> user <%= node['haproxy']['stats_socket_user'] %> group <%= node['haproxy']['stats_socket_group'] %>
 <% end -%>
+<% node['haproxy']['global_listener'].each do |option| -%>
+  <%= option %>
+<% end -%>
 
 defaults
   log     global
-  mode    http
-  retries 3
+  mode    <%= node['haproxy']['global_mode'] %>
+  retries <%= node['haproxy']['global_retries'] %>
 <% @defaults_timeouts.sort.map do | value, time | -%>
   timeout <%= value %> <%= time %>
 <% end -%>
@@ -22,6 +23,9 @@ defaults
   option <%= option %>
 <% end -%>
   balance  <%= node['haproxy']['balance_algorithm'] %>
+<% node['haproxy']['defaults_listener'].each do |option| -%>
+  <%= option %>
+<% end -%>
 
 # Set up application listeners here.
 


### PR DESCRIPTION
The haproxy configuration currently has hard-coded configurations in the global / defaults stanzas and does not allow additional options to be added.  This changes the following:
- Allow the log servers to be configurable
- Allow the global mode / retries to be configurable
- Allow additional, unknown options to be added to the global / defaults stanzas
