### PR TITLE
Fixes config_dir when installing haproxy from source

### DIFF
--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -31,7 +31,7 @@ package 'zlib1g-dev' do
   only_if { node['haproxy']['source']['use_zlib'] }
 end
 
-node.set['haproxy']['conf_dir'] = "#{node['haproxy']['source']['prefix']}/etc"
+node.default['haproxy']['conf_dir'] = "#{node['haproxy']['source']['prefix']}/#{node['haproxy']['conf_dir']}"
 
 remote_file "#{Chef::Config[:file_cache_path]}/haproxy-#{node['haproxy']['source']['version']}.tar.gz" do
   source node['haproxy']['source']['url']


### PR DESCRIPTION
The current implementation will prepend the source prefix, which is fine, but then it just assumes your config dir was "/etc" which I believe is incorrect behavior.

This change respects the original `config_dir` value and just adds the prefix, so that **/etc/haproxy** will become **/usr/local/etc/haproxy**.

Lastly, since recipes have high attribute precedence than attributes, I have changed `node.set` to `node.default`. This produces the same behavior as before and allows a wrapper cookbooks to use `set` level instead of `override`.
