### PR TITLE
Enabling stats socket via attributes throws an error

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+default['haproxy']['user'] = "haproxy"
+default['haproxy']['group'] = "haproxy"
+
 default['haproxy']['enable_default_http'] = true
 default['haproxy']['incoming_address'] = "0.0.0.0"
 default['haproxy']['incoming_port'] = 80
@@ -56,9 +59,6 @@ default['haproxy']['defaults_timeouts']['connect'] = "5s"
 default['haproxy']['defaults_timeouts']['client'] = "50s"
 default['haproxy']['defaults_timeouts']['server'] = "50s"
 default['haproxy']['cookie'] = nil
-
-default['haproxy']['user'] = "haproxy"
-default['haproxy']['group'] = "haproxy"
 
 default['haproxy']['global_max_connections'] = 4096
 default['haproxy']['member_max_connections'] = 100


### PR DESCRIPTION
Stats socket user and group rely on the values `default['haproxy']['user']` and `default['haproxy']['group]`, so it makes sense to define those values before using them ( ruby evaluates files top to bottom ).
