### PR TITLE
Fix CPU affinity tuning recipe

### DIFF
--- a/recipes/tuning.rb
+++ b/recipes/tuning.rb
@@ -22,5 +22,5 @@ include_recipe "cpu::affinity"
 cpu_affinity "set affinity for haproxy" do
   pid node['haproxy']['pid_file']
   cpu 0
-  subscribes :set, resources("service[haproxy]"), :immediately
+  subscribes :set, 'service[haproxy]'
 end


### PR DESCRIPTION
Attempting to create a run list using this recipe and the default one results in an exception during the first convergence of a node.

``` ruby
# example run list
include_recipe 'haproxy'
include_recipe 'haproxy::tuning'
```

This happens because the `cpu_affinity` resource triggers immediately after the `'service[haproxy]'` resource is created. Since that service resource doesn't start HAProxy immediately, we end up with a situation where we're trying to change the cpu affiinity for a process that does not yet exist.

The easy fix it use the resources default notification time (i.e. _delayed_)
