### PR TITLE
Fix dynamic config generation

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -17,6 +17,10 @@ module ChefHaproxy
       result = []
       case thing
       when Hash
+        if thing.empty?
+          result << prefix
+        end
+
         thing.each do |key, value|
           case value
           when Hash, Array
@@ -33,7 +37,14 @@ module ChefHaproxy
         end
       when Array
         thing.each do |v|
-          result << [prefix, v.to_s].compact.join(' ')
+          case v
+          when Hash
+            v.each do |key, value|
+              result.push config_generator(value, [prefix, key.to_s].compact.join(' '))
+            end
+          else
+            result << [prefix, v.to_s].compact.join(' ')
+          end
         end
       else
         raise TypeError.new("Expecting Hash or Array type. Received: #{thing.class}")

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -19,20 +19,20 @@ module ChefHaproxy
       when Hash
         if thing.empty?
           result << prefix
-        end
-
-        thing.each do |key, value|
-          case value
-          when Hash, Array
-            result.push config_generator(
-              value, [prefix, key.to_s].compact.join(' ')
-            )
-          when TrueClass, FalseClass
-            if(value)
-              result << [prefix, key.to_s].compact.join(' ')
+        else
+          thing.each do |key, value|
+            case value
+            when Hash, Array
+              result.push config_generator(
+                value, [prefix, key.to_s].compact.join(' ')
+              )
+            when TrueClass, FalseClass
+              if(value)
+                result << [prefix, key.to_s].compact.join(' ')
+              end
+            else
+              result << [prefix, key.to_s, value.to_s].compact.join(' ')
             end
-          else
-            result << [prefix, key.to_s, value.to_s].compact.join(' ')
           end
         end
       when Array
@@ -40,7 +40,7 @@ module ChefHaproxy
           case v
           when Hash
             v.each do |key, value|
-              result.push config_generator(value, [prefix, key.to_s].compact.join(' '))
+              result << [prefix, key.to_s, value.flatten].compact.join(' ')
             end
           else
             result << [prefix, v.to_s].compact.join(' ')

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -40,7 +40,17 @@ module ChefHaproxy
           case v
           when Hash
             v.each do |key, value|
-              result << [prefix, key.to_s, value.flatten].compact.join(' ')
+              if value.is_a?(Hash)
+                value = value.map do |attrib, val|
+                  case val
+                  when TrueClass, FalseClass
+                    attrib if val
+                  else
+                    [attrib, val].join(' ')
+                  end
+                end
+              end
+              result << [prefix, key.to_s, value].compact.join(' ')
             end
           else
             result << [prefix, v.to_s].compact.join(' ')

--- a/templates/default/haproxy.dynamic.cfg.erb
+++ b/templates/default/haproxy.dynamic.cfg.erb
@@ -1,4 +1,11 @@
 <% @config.each do |top_level_key, top_level_value| -%>
+  <% if top_level_key == 'global' || top_level_key == 'defaults' %>
 <%= top_level_key %>
 <%= ChefHaproxy.config_generator(top_level_value, '    ') %>
+  <% else %>
+    <% top_level_value.each do |id, value| %>
+<%= [top_level_key, id].join(' ') %>
+<%= ChefHaproxy.config_generator(value, '    ') %>
+    <% end %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
This fixes #60. The `config_generator` looks kind of messy. I am open for suggestions to improve this. But for now, this generates syntactically correct haproxy.cnf.
