### PR TITLE
Allow a package version to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Attributes
 - `node['haproxy']['source']['target_cpu']` - the target cpu used to `make` haproxy
 - `node['haproxy']['source']['target_arch']` - the target arch used to `make` haproxy
 - `node['haproxy']['source']['use_pcre']` - whether to build with libpcre support
+- `node['haproxy']['package']['version'] - the version of haproxy to install, default latest
 
 Recipes
 -------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -79,6 +79,8 @@ default['haproxy']['source']['use_pcre'] = false
 default['haproxy']['source']['use_openssl'] = false
 default['haproxy']['source']['use_zlib'] = false
 
+default['haproxy']['package']['version'] = nil
+
 default['haproxy']['listeners'] = {
   'listen' => {},
   'frontend' => {},

--- a/metadata.rb
+++ b/metadata.rb
@@ -228,3 +228,8 @@ attribute "haproxy/source/use_pcre",
   :display_name => "HAProxy source use PCRE",
   :description => "Whether to build with libpcre support.",
   :required => "optional"
+
+attribute "haproxy/package/version",
+  :display_name => "HAProxy package version",
+  :description => "The version of haproxy to install.",
+  :required => "optional"

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -17,7 +17,9 @@
 # limitations under the License.
 #
 
-package "haproxy"
+package "haproxy" do
+  version node['haproxy']['package']['version'] if node['haproxy']['package']['version']
+end
 
 directory node['haproxy']['conf_dir']
 

--- a/spec/recipes/lb_spec.rb
+++ b/spec/recipes/lb_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+haproxyConfigFile = '/etc/haproxy/haproxy.cfg'
+
+describe 'haproxy::install_package' do
+  let(:chef_run) { ChefSpec::Runner.new().converge(described_recipe) }
+
+  it 'Installs the haproxy package' do
+    expect(chef_run).to install_package 'haproxy'
+  end
+
+  givenVersion = '1.2.3.4'
+
+  # re-converge
+  let(:chef_run) do
+    ChefSpec::Runner.new do |node|
+      node.set['haproxy']['package']['version'] = givenVersion 
+    end.converge(described_recipe)
+  end
+
+  it 'Installs the haproxy package at a given version' do
+    expect(chef_run).to install_package('haproxy').with_version(givenVersion)
+  end
+
+end
+
+
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,25 @@
+# Added by ChefSpec
+require 'chefspec'
+
+# Uncomment to use ChefSpec's Berkshelf extension
+require 'chefspec/berkshelf'
+
+RSpec.configure do |config|
+  # Specify the path for Chef Solo to find cookbooks
+  # config.cookbook_path = '/var/cookbooks'
+
+  # Specify the path for Chef Solo to find roles
+  # config.role_path = '/var/roles'
+
+  # Specify the Chef log_level (default: :warn)
+  # config.log_level = :debug
+
+  # Specify the path to a local JSON file with Ohai data
+  # config.path = 'ohai.json'
+
+  # Specify the operating platform to mock Ohai data from
+  # config.platform = 'ubuntu'
+
+  # Specify the operating version to mock Ohai data from
+  # config.version = '12.04'
+end


### PR DESCRIPTION
This change allows a package version for install to be specified and comes with a ChefSpec test to verify that the change made works fine.

Ran `kitchen test` after the changes and everything still seems to work fine
