### PR TITLE
Rebuild if the version number is different

### DIFF
--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -53,7 +53,7 @@ bash "compile_haproxy" do
     cd haproxy-#{node['haproxy']['source']['version']}
     #{make_cmd} && make install PREFIX=#{node['haproxy']['source']['prefix']}
   EOH
-  creates "#{node['haproxy']['source']['prefix']}/sbin/haproxy"
+  not_if "grep #{node['haproxy']['source']['version']} $(#{node['haproxy']['source']['prefix']}/sbin/haproxy -v)"
 end
 
 user "haproxy" do


### PR DESCRIPTION
Since the haproxy binary doesn't include any version information in the name,
this tries to read the version from the binary (if it's installed) and check the
output for the requested version number. If it's not found: rebuild.
