### PR TITLE
Added entries for existing socket options to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Attributes
 - `node['haproxy']['enable_admin']` - whether to enable the admin interface. default true. Listens on port 22002.
 - `node['haproxy']['admin']['address_bind']` - sets the address to bind the administrative interface on, 127.0.0.1 by default
 - `node['haproxy']['admin']['port']` - sets the port for the administrative interface, 22002 by default
+- `node['haproxy']['enable_stats_socket']` - controls haproxy socket creation, false by default
+- `node['haproxy']['stats_socket_path']` - location of haproxy socket, "/var/run/haproxy.sock" by default
+- `node['haproxy']['stats_socket_user']` - user for haproxy socket, default is node['haproxy']['user']
+- `node['haproxy']['stats_socket_group']` - group for haproxy socket, default is node['haproxy']['group']
 - `node['haproxy']['pid_file']` - the PID file of the haproxy process, used in the tuning recipe.
 - `node['haproxy']['defaults_options']` - an array of options to use for the config file's `defaults` stanza, default is ["httplog", "dontlognull", "redispatch"]
 - `node['haproxy']['defaults_timeouts']['connect']` - connect timeout in defaults stanza


### PR DESCRIPTION
The attributes related to the stats_socket weren't in the README.md file.  Added.
