### PR TITLE
only create default config when attribute is set

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -87,3 +87,5 @@ default['haproxy']['listeners'] = {
   'frontend' => {},
   'backend' => {}
 }
+
+default['haproxy']['create_default_config'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -104,6 +104,7 @@ template "#{node['haproxy']['conf_dir']}/haproxy.cfg" do
     :defaults_options => haproxy_defaults_options,
     :defaults_timeouts => haproxy_defaults_timeouts
   )
+  only_if { node['haproxy']['create_default_config'] }
 end
 
 service "haproxy" do


### PR DESCRIPTION
This adds an attribute to suppress the generation of the default config.
Otherwise, when configuring via the lwrp, the config is written two times on every chef run, resulting in a haproxy reload everytime.
With the new attribute `create_default_config`set to false, this should not happen anymore.
