### PR TITLE
Sort pool members by hostname to avoid haproxy reload

### DIFF
--- a/recipes/app_lb.rb
+++ b/recipes/app_lb.rb
@@ -40,6 +40,9 @@ pool_members.map! do |member|
   {:ipaddress => server_ip, :hostname => member['hostname']}
 end
 
+pool_members.sort! do |a,b|
+  a[:hostname].downcase <=> b[:hostname].downcase
+end
 
 pool = ["options httpchk #{node['haproxy']['httpchk']}"] if node['haproxy']['httpchk']
 servers = pool_members.uniq.map do |s|


### PR DESCRIPTION
Sort pool members by hostname to avoid template modification and haproxy reload
