### PR TITLE
support amazon linux with copy of rhel startup script.

### DIFF
--- a/templates/amazon/haproxy-init.erb
+++ b/templates/amazon/haproxy-init.erb
@@ -1,0 +1,112 @@
+#!/bin/sh
+#
+# haproxy
+#
+# chkconfig:   - 85 15
+# description:  HAProxy is a free, very fast and reliable solution \
+#               offering high availability, load balancing, and \
+#               proxying for TCP and  HTTP-based applications
+# processname: haproxy
+# config:      <%= @conf_dir %>/haproxy.cfg
+# pidfile:     /var/run/haproxy.pid
+
+# Written by Chef on <%= @hostname %>
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+# Source networking configuration.
+. /etc/sysconfig/network
+
+# Check that networking is up.
+[ "$NETWORKING" = "no" ] && exit 0
+
+config="<%= @conf_dir %>/haproxy.cfg"
+exec="<%= @prefix %>/sbin/haproxy"
+prog=$(basename $exec)
+
+[ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+lockfile=/var/lock/subsys/haproxy
+
+check() {
+    $exec -c -V -f $config
+}
+
+start() {
+    $exec -c -q -f $config
+    if [ $? -ne 0 ]; then
+        echo "Errors in configuration file, check with $prog check."
+        return 1
+    fi
+ 
+    echo -n $"Starting $prog: "
+    # start it up here, usually something like "daemon $exec"
+    daemon $exec -D -f $config -p /var/run/$prog.pid
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    # stop it here, often "killproc $prog"
+    killproc $prog 
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    $exec -c -q -f $config
+    if [ $? -ne 0 ]; then
+        echo "Errors in configuration file, check with $prog check."
+        return 1
+    fi
+    stop
+    start
+}
+
+reload() {
+    $exec -c -q -f $config
+    if [ $? -ne 0 ]; then
+        echo "Errors in configuration file, check with $prog check."
+        return 1
+    fi
+    echo -n $"Reloading $prog: "
+    $exec -D -f $config -p /var/run/$prog.pid -sf $(cat /var/run/$prog.pid)
+    retval=$?
+    echo
+    return $retval
+}
+
+force_reload() {
+    restart
+}
+
+fdr_status() {
+    status $prog
+}
+
+case "$1" in
+    start|stop|restart|reload)
+        $1
+        ;;
+    force-reload)
+        force_reload
+        ;;
+    check)
+        check
+        ;;
+    status)
+        fdr_status
+        ;;
+    condrestart|try-restart)
+    [ ! -f $lockfile ] || restart
+  ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|try-restart|reload|force-reload}"
+        exit 2
+esac


### PR DESCRIPTION
While amazon linux is part of the rhel platform family, it's platform is "amazon". The template resource that writes the init script operates on the platform and not platform_family.  This allows amazon linux to use the cookbook with a copy of the rhel init script.
