### PR TITLE
Bugfix (typo) in option httpchk. The keyword is 'option' (singular)

### DIFF
--- a/recipes/app_lb.rb
+++ b/recipes/app_lb.rb
@@ -44,7 +44,7 @@ pool_members.sort! do |a,b|
   a[:hostname].downcase <=> b[:hostname].downcase
 end
 
-pool = ["options httpchk #{node['haproxy']['httpchk']}"] if node['haproxy']['httpchk']
+pool = ["option httpchk #{node['haproxy']['httpchk']}"] if node['haproxy']['httpchk']
 servers = pool_members.uniq.map do |s|
   "#{s[:hostname]} #{s[:ipaddress]}:#{node['haproxy']['member_port']} weight 1 maxconn #{node['haproxy']['member_max_connections']} check"
 end
@@ -56,7 +56,7 @@ end
 
 if node['haproxy']['enable_ssl']
   pool = ["option ssl-hello-chk"]
-  pool << ["options httpchk #{node['haproxy']['ssl_httpchk']}"] if node['haproxy']['ssl_httpchk']
+  pool << ["option httpchk #{node['haproxy']['ssl_httpchk']}"] if node['haproxy']['ssl_httpchk']
   servers = pool_members.uniq.map do |s|
     "#{s[:hostname]} #{s[:ipaddress]}:#{node['haproxy']['ssl_member_port']} weight 1 maxconn #{node['haproxy']['member_max_connections']} check"
   end


### PR DESCRIPTION
The line 'options httpchk ...' result in invalid configuration. This patch fixes the problem. Please merge and include in the next release of this cookbook.
