### PR TITLE
Support user lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,41 @@ Finally you can also configure frontends and backends by specify the type attrib
 
 Instead of using lwrp, you can use `node['haproxy']['listeners']` to configure all kind of listeners (`listen`, `frontend` and `backend`)
 
+### haproxy_userlist
+Define a user list, to which users (`haproxy_user`) and groups (`haproxy_group`) can be added to provide access control on frontend/backend/listen sections.
+
+```ruby
+haproxy_userlist 'admins' do
+  action :create
+end
+```
+
+### haproxy_user
+Define a user within an HAProxy userlist. The userlist must be previously defined using an `haproxy_userlist` resource.
+
+If a password is provided in plain text, it will automatically be cryptographically hashed with a securely generated salt. Pre-computed hashes can also be provided.
+
+```ruby
+haproxy_user 'brian' do
+  userlist 'admins'
+  password 'changeme'
+  insecure_password false
+  groups ['group1']
+  action :create
+end
+```
+
+### haproxy_group
+Define a group of users within an HAProxy userlist. The userlist must be previously defined using an `haproxy_userlist` resource.
+
+```ruby
+haproxy_group 'group2' do
+  userlist 'admins'
+  users ['brian', 'jane']
+  action :create
+end
+```
+
 ### haproxy_config
 
 This provider is used to write the actual haproxy.cfg file to the system. Location of

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -6,3 +6,4 @@ default[:haproxy][:config][:defaults][:timeout][:client] = '10s'
 default[:haproxy][:config][:defaults][:timeout][:server] = '10s'
 default[:haproxy][:config][:defaults][:timeout][:connect] = '10s'
 default[:haproxy][:config][:defaults][:options] = []
+default[:haproxy][:config][:defaults][:params] = []

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -92,3 +92,4 @@ default['haproxy']['listeners'] = {
   'frontend' => {},
   'backend' => {}
 }
+default['haproxy']['userlists'] = {}

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -17,6 +17,7 @@ def install_haproxy_config
     mode 00644
     variables(
       :defaults_options => defaults_options,
+      :defaults_params => defaults_params,
       :defaults_timeouts => defaults_timeouts
     )
   end
@@ -28,6 +29,10 @@ def defaults_options
     options.push("forwardfor")
   end
   return options.uniq
+end
+
+def defaults_params
+  node['haproxy']['defaults_params']
 end
 
 def defaults_timeouts

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -1,0 +1,8 @@
+use_inline_resources if defined?(use_inline_resources)
+
+action :create do
+  group = "group #{new_resource.name}"
+  group << " users #{new_resource.users.join(',')}" if new_resource.users
+  node.default['haproxy']['userlists'][new_resource.userlist]['groups'][new_resource.name] = group
+end
+

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -1,0 +1,33 @@
+use_inline_resources if defined?(use_inline_resources)
+
+require 'digest/sha2'
+require 'securerandom'
+
+action :create do
+  user = "user #{new_resource.username}"
+
+  if new_resource.insecure_password
+    user << " insecure-password #{new_resource.password}"
+    node.normal_attrs['haproxy']['userlists'][new_resource.userlist]['stored_salts'].delete(new_resource.username)
+  elsif new_resource.password[0..2] == '$6$'
+    user << " password #{new_resource.password}"
+  else
+    salt = node['haproxy']['userlists'][new_resource.userlist]['stored_salts'][new_resource.username]
+    unless salt
+      salt = '$6$' + case Chef::Config[:solo]
+                     when true
+                       digest_key = new_resource.userlist + new_resource.username
+                       name_shasum = Digest::SHA512.new.digest(digest_key).unpack('L_')[0]
+                       Random.new(name_shasum).rand(36**8)
+                     else
+                       salt = SecureRandom.random_number(36**8)
+                     end.to_s(36)
+    end
+    crypted_pw = new_resource.password.crypt(salt)
+    node.normal['haproxy']['userlists'][new_resource.userlist]['stored_salts'][new_resource.username] = crypted_pw
+    user << " password #{crypted_pw}"
+  end
+
+  user << " groups #{new_resource.groups.join(',')}" if new_resource.groups
+  node.set['haproxy']['userlists'][new_resource.userlist]['users'][new_resource.username] = user
+end

--- a/providers/userlist.rb
+++ b/providers/userlist.rb
@@ -1,0 +1,10 @@
+use_inline_resources if defined?(use_inline_resources)
+
+action :create do
+  node.default['haproxy']['userlists'][new_resource.name] = {
+    'groups' => {},
+    'stored_salts' => {},
+    'users' => {}
+  }
+end
+

--- a/resources/group.rb
+++ b/resources/group.rb
@@ -1,0 +1,7 @@
+actions :create
+default_action :create
+
+
+attribute :name, :kind_of => String, :name_attribute => true
+attribute :userlist, :kind_of => String, :required => true
+attribute :users, :kind_of => [Array, NilClass], :default => nil

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -1,0 +1,9 @@
+actions :create
+default_action :create
+
+
+attribute :username, :kind_of => String, :name_attribute => true
+attribute :groups, :kind_of => [Array, NilClass], :default => nil
+attribute :insecure_password, :kind_of => [FalseClass, TrueClass], :default => false
+attribute :password, :kind_of => String, :required => true
+attribute :userlist, :kind_of => String, :required => true

--- a/resources/userlist.rb
+++ b/resources/userlist.rb
@@ -1,0 +1,5 @@
+actions :create
+default_action :create
+
+
+attribute :name, :kind_of => String, :name_attribute => true

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -35,6 +35,9 @@ defaults
 <% @defaults_options.sort.each do | option | -%>
   option <%= option %>
 <% end -%>
+<% @defaults_params.sort.each do | param | -%>
+  <%= param %>
+<% end -%>
   balance  <%= node['haproxy']['balance_algorithm'] %>
 
 # Set up application listeners here.

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -14,6 +14,17 @@ global
   <%= option %> <%= value %>
 <% end %>
 
+<% node['haproxy']['userlists'].each do |name, userlist| -%>
+userlist <%= name %>
+<% (userlist['groups'] || {}).keys.sort.each do |k| -%>
+  <%= userlist['groups'][k] %>
+<% end -%>
+<% (userlist['users'] || {}).keys.sort.each do |k| -%>
+  <%= userlist['users'][k] %>
+<% end -%>
+
+<% end -%>
+
 defaults
   log     global
   mode    <%= node['haproxy']['mode'] %>


### PR DESCRIPTION
Adds three new resources/providers, `haproxy_userlist`, `haproxy_user` and `haproxy_group`, which can be used to define access control lists for authentication.

Password crypting is handled automatically. During Chef runs with persistent node attribute storage, salts are securely generated and stored. When no persistent attribute storage is available (i.e. chef-solo), salts are generated deterministically from the userlist+username pair.
