### PR TITLE
Adding TPROXY compile flag for install_source recipe.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -83,6 +83,9 @@ default['haproxy']['source']['target_arch'] = ''
 default['haproxy']['source']['use_pcre'] = false
 default['haproxy']['source']['use_openssl'] = false
 default['haproxy']['source']['use_zlib'] = false
+default['haproxy']['source']['use_tproxy'] = false
+default['haproxy']['source']['use_tproxy'] = false
+default['haproxy']['source']['use_splice'] = false
 
 default['haproxy']['package']['version'] = nil
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -84,7 +84,6 @@ default['haproxy']['source']['use_pcre'] = false
 default['haproxy']['source']['use_openssl'] = false
 default['haproxy']['source']['use_zlib'] = false
 default['haproxy']['source']['use_tproxy'] = false
-default['haproxy']['source']['use_tproxy'] = false
 default['haproxy']['source']['use_splice'] = false
 
 default['haproxy']['package']['version'] = nil

--- a/templates/default/source_compile.sh.erb
+++ b/templates/default/source_compile.sh.erb
@@ -1,0 +1,3 @@
+tar xzf haproxy-<%= @version %>.tar.gz
+cd haproxy-<%= @version %>
+make TARGET=<%= @target %><%= @cpu.empty? ? "" : " CPU=#{@cpu}" %><%= @arch.empty? ? "": " ARCH=#{@arch}" %><%= @use_pcre ? " USE_PCRE=1" : "" %><%= @use_openssl ? " USE_OPENSSL=1" : "" %><%= @use_zlib ? " USE_ZLIB=1" : "" %><%= @use_tproxy ? " USE_LINUX_TPROXY=1" : "" %><%= @use_splice ? " USE_LINUX_SPLICE=1" : "" %> && make install PREFIX=<%= @prefix %>


### PR DESCRIPTION
I wanted to use the TPROXY setup so that I could do SSL pass through and keep the clients IP address on the application node in the access log (instead of the haproxy node). I added two flags, the setup for both tproxy and splice. The splice flag is for performance.

I also changed how the gating of the compile/install works. Before, if you changed the version or flags used then you would have to manually remove /usr/src/local/bin/haproxy to get it to do the compile/install. I changed it so that the recipe uses a template to create an sh script to do the make and make install commands (basically I moved the bash block into a script). Any changes to the attributes (compile flags, version change, etc) will now result in haproxy being recompiled and installed.
