### PR TITLE
haproxy resource reload instead of restart on config change

### DIFF
--- a/recipes/app_lb.rb
+++ b/recipes/app_lb.rb
@@ -59,5 +59,5 @@ if node['haproxy']['enable_ssl']
 end
 
 haproxy_config "Create haproxy.cfg" do
-  notifies :restart, "service[haproxy]", :delayed
+  notifies :reload, "service[haproxy]", :delayed
 end

--- a/recipes/manual.rb
+++ b/recipes/manual.rb
@@ -100,5 +100,5 @@ unless node['haproxy']['global_options'].is_a?(Hash)
 end
 
 haproxy_config "Create haproxy.cfg" do
-  notifies :restart, "service[haproxy]", :delayed
+  notifies :reload, "service[haproxy]", :delayed
 end


### PR DESCRIPTION
In the latest changes, it looks like the haproxy_config resource now notifies the haproxy resource to restart when the haproxy.cfg file is created/changed.  This should probably be a reload notification instead to try to minimize downtime impact.
