### PR TITLE
Adding generic arg hash for socket conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Attributes
 - `node['haproxy']['admin']['options']` - sets extras config parameters on the administrative interface, 'stats uri /' by default
 - `node['haproxy']['enable_stats_socket']` - controls haproxy socket creation, false by default
 - `node['haproxy']['stats_socket_path']` - location of haproxy socket, "/var/run/haproxy.sock" by default
-- `node['haproxy']['stats_socket_user']` - user for haproxy socket, default is node['haproxy']['user']
-- `node['haproxy']['stats_socket_group']` - group for haproxy socket, default is node['haproxy']['group']
+- `node['haproxy']['stats_socket']['user']` - user for haproxy socket, default is node['haproxy']['user']
+- `node['haproxy']['stats_socket']['group']` - group for haproxy socket, default is node['haproxy']['group']
 - `node['haproxy']['pid_file']` - the PID file of the haproxy process, used in the tuning recipe.
 - `node['haproxy']['global_options']` - global options, like tuning. Format must be of `{ 'option' => 'value' }`; defaults to `{}`.
 - `node['haproxy']['defaults_options']` - an array of options to use for the config file's `defaults` stanza, default is ["httplog", "dontlognull", "redispatch"]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,8 +54,8 @@ default['haproxy']['admin']['port'] = 22002
 default['haproxy']['admin']['options'] = { 'stats' => 'uri /' }
 default['haproxy']['enable_stats_socket'] = false
 default['haproxy']['stats_socket_path'] = "/var/run/haproxy.sock"
-default['haproxy']['stats_socket_user'] = node['haproxy']['user']
-default['haproxy']['stats_socket_group'] = node['haproxy']['group']
+default['haproxy']['stats_socket']['user'] = node['haproxy']['user']
+default['haproxy']['stats_socket']['group'] = node['haproxy']['group']
 default['haproxy']['pid_file'] = "/var/run/haproxy.pid"
 
 default['haproxy']['defaults_options'] = ["httplog", "dontlognull", "redispatch"]

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -8,7 +8,7 @@ global
   user <%= node['haproxy']['user'] %>
   group <%= node['haproxy']['group'] %>
 <% if node['haproxy']['enable_stats_socket'] -%>
-  stats socket <%= node['haproxy']['stats_socket_path'] %> user <%= node['haproxy']['stats_socket_user'] %> group <%= node['haproxy']['stats_socket_group'] %>
+  stats socket <%= node['haproxy']['stats_socket_path'] -%> <%= node['haproxy']['stats_socket'].map{|k, v| "#{k} #{v}"}.flatten.join(' ') %>
 <% end -%>
 <% node['haproxy']['global_options'].sort.each do |option, value| %>
   <%= option %> <%= value %>


### PR DESCRIPTION
Ohai !

Currently there's no other way to pass more attributes to haproxy socket conf.
So I made a little change to use a more generic way to put args in socket line.

Now we are able to set :

```
default['haproxy']['stats_socket']['level'] = 'admin'
```

_or any other attribute available at http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#9.2_

and then get this in our conf : 

```
  stats socket /var/run/haproxy.sock user haproxy group haproxy level admin
```
