### PR TITLE
CentOS7 compatibility

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,10 +4,14 @@ driver_config:
   require_chef_omnibus: true
 
 platforms:
-- name: centos-6.3
+- name: centos-6.4
   driver_config:
-    box: opscode-centos-6.3
+    box: opscode-centos-6.4
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
+- name: centos-7.1
+  driver_config:
+    box: opscode-centos-7.1
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_centos-7.1_provisionerless.box
 - name: ubuntu-12.04
   driver_config:
     box: opscode-ubuntu-12.04
@@ -30,18 +34,43 @@ platforms:
       haproxy:
         test:
           netcat_package: netcat
-
+- name: debian-7.9
+  driver_config:
+    box: opscode-debian-7.9
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.9_chef-provisionerless.box
+  run_list:
+  - recipe[apt]
+  provisioner:
+    attributes:
+      haproxy:
+        test:
+          netcat_package: netcat
+- name: debian-8.2
+  driver_config:
+    box: opscode-debian-8.2
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-8.2_chef-provisionerless.box
+  run_list:
+  - recipe[apt]
+  provisioner:
+    attributes:
+      haproxy:
+        test:
+          netcat_package: netcat
 suites:
 - name: default
   run_list:
   - recipe[haproxy]
   attributes: {}
-- name: lwrp
+
+- name: lwrp-package
+  # No haproxy package on debian7 with default apt repo
+  excludes:
+    - debian-7.9
   run_list:
   - recipe[haproxy]
   - recipe[haproxy-test]
   attributes:
-    haproxy:
+    haproxy: &default_attr
       enable_default_http: false
       global_options: ['quiet']
       listeners:
@@ -54,3 +83,11 @@ suites:
             - server netcat1 127.0.0.1:5001
             - server netcat2 127.0.0.1:5002
 
+- name: lwrp-source
+  run_list:
+  - recipe[haproxy]
+  - recipe[haproxy-test]
+  attributes:
+    haproxy:
+      <<: *default_attr
+      install_method: 'source'

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -72,7 +72,6 @@ suites:
   attributes:
     haproxy: &default_attr
       enable_default_http: false
-      global_options: ['quiet']
       listeners:
         listen:
           lb_test:

--- a/Cheffile
+++ b/Cheffile
@@ -1,10 +1,11 @@
 #!/usr/bin/env ruby
 #^syntax detection
 
-site 'http://community.chef.io/api/v1'
+site 'http://supermarket.chef.io/api/v1'
 
 cookbook "haproxy", :path => '.'
 
 cookbook "apt"
 cookbook "yum"
 cookbook "haproxy-test", :path => './test/cookbooks/haproxy-test'
+cookbook 'poise-service'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -58,6 +58,8 @@ default['haproxy']['pid_file'] = "/var/run/haproxy.pid"
 default['haproxy']['defaults_options'] = ["httplog", "dontlognull", "redispatch"]
 default['haproxy']['x_forwarded_for'] = false
 default['haproxy']['global_options'] = {}
+# debug_options could be either "debug" or "quiet". "quiet" by default.
+default['haproxy']['debug_options'] = 'quiet'
 default['haproxy']['defaults_timeouts']['connect'] = "5s"
 default['haproxy']['defaults_timeouts']['client'] = "50s"
 default['haproxy']['defaults_timeouts']['server'] = "50s"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,7 +69,6 @@ default['haproxy']['frontend_max_connections'] = 2000
 default['haproxy']['frontend_ssl_max_connections'] = 2000
 
 default['haproxy']['install_method'] = 'package'
-default['haproxy']['conf_dir'] = '/etc/haproxy'
 
 default['haproxy']['source']['version'] = '1.4.22'
 default['haproxy']['source']['url'] = 'http://haproxy.1wt.eu/download/1.4/src/haproxy-1.4.22.tar.gz'
@@ -88,4 +87,16 @@ default['haproxy']['listeners'] = {
   'listen' => {},
   'frontend' => {},
   'backend' => {}
+}
+
+default['haproxy']['conf_dir'] = ::File.join(node['haproxy']['install_method'].eql?('source') ? node['haproxy']['source']['prefix'] : '/', 'etc', 'haproxy')
+default['haproxy']['global_prefix'] = node['haproxy']['install_method'].eql?('source') ? node['haproxy']['source']['prefix'] : '/usr'
+# We keep the init script for sysvinit
+default['haproxy']['poise_service']['options'] = {
+  sysvinit: {
+    template:   'haproxy-init.erb',
+    hostname:   node['hostname'],
+    conf_dir:   node['haproxy']['conf_dir'],
+    prefix:     node['haproxy']['global_prefix'],
+  },
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,6 +15,7 @@ end
 
 depends           "cpu", ">= 0.2.0"
 depends           "build-essential"
+depends           'poise-service'
 
 attribute "haproxy/incoming_address",
   :display_name => "HAProxy incoming address",

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@ cookbook_file "/etc/default/haproxy" do
   owner "root"
   group "root"
   mode 00644
-  notifies :restart, "service[haproxy]"
+  notifies :restart, "poise_service[haproxy]"
 end
 
 
@@ -104,14 +104,19 @@ template "#{node['haproxy']['conf_dir']}/haproxy.cfg" do
   owner "root"
   group "root"
   mode 00644
-  notifies :reload, "service[haproxy]"
+  notifies :reload, "poise_service[haproxy]"
   variables(
     :defaults_options => haproxy_defaults_options,
     :defaults_timeouts => haproxy_defaults_timeouts
   )
 end
 
-service "haproxy" do
-  supports :restart => true, :status => true, :reload => true
-  action [:enable, :start]
+haproxy_command = ::File.join(node['haproxy']['global_prefix'], 'sbin', 'haproxy')
+haproxy_config_file = ::File.join(node['haproxy']['conf_dir'], 'haproxy.cfg')
+poise_service "haproxy" do
+  command "#{haproxy_command} -f #{haproxy_config_file}"
+  node['haproxy']['poise_service']['options'].each do |k, v|
+    options k, v
+  end
+  action :enable
 end

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -22,15 +22,3 @@ package "haproxy" do
 end
 
 directory node['haproxy']['conf_dir']
-
-template "/etc/init.d/haproxy" do
-  source "haproxy-init.erb"
-  owner "root"
-  group "root"
-  mode 00755
-  variables(
-    :hostname => node['hostname'],
-    :conf_dir => node['haproxy']['conf_dir'],
-    :prefix => "/usr"
-  )
-end

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -42,8 +42,6 @@ package zlib_pkg do
   only_if { node['haproxy']['source']['use_zlib'] }
 end
 
-node.default['haproxy']['conf_dir'] = ::File.join(node['haproxy']['source']['prefix'], node['haproxy']['conf_dir'])
-
 download_file_path = ::File.join(Chef::Config[:file_cache_path], "haproxy-#{node['haproxy']['source']['version']}.tar.gz")
 remote_file download_file_path do
   source node['haproxy']['source']['url']
@@ -85,14 +83,3 @@ end
 
 directory node['haproxy']['conf_dir']
 
-template "/etc/init.d/haproxy" do
-  source "haproxy-init.erb"
-  owner "root"
-  group "root"
-  mode 00755
-  variables(
-    :hostname => node['hostname'],
-    :conf_dir => node['haproxy']['conf_dir'],
-    :prefix => node['haproxy']['source']['prefix']
-  )
-end

--- a/recipes/tuning.rb
+++ b/recipes/tuning.rb
@@ -22,5 +22,5 @@ include_recipe "cpu::affinity"
 cpu_affinity "set affinity for haproxy" do
   pid node['haproxy']['pid_file']
   cpu 0
-  subscribes :set, 'service[haproxy]'
+  subscribes :set, 'poise_service[haproxy]'
 end

--- a/templates/default/haproxy-init.erb
+++ b/templates/default/haproxy-init.erb
@@ -11,12 +11,12 @@
 
 # Author: Arnaud Cornet <acornet@debian.org>
 
-# Written by Chef on <%= @hostname %>
+# Written by Chef on <%= @options['hostname'] %>
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 PIDFILE=/var/run/haproxy.pid
-CONFIG=<%= @conf_dir %>/haproxy.cfg
-HAPROXY=<%= @prefix %>/sbin/haproxy
+CONFIG=<%= @options['conf_dir'] %>/haproxy.cfg
+HAPROXY=<%= @options['prefix'] %>/sbin/haproxy
 EXTRAOPTS=
 ENABLED=0
 

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -3,8 +3,8 @@ global
   log 127.0.0.1   local1 notice
   #log loghost    local0 info
   maxconn <%= node['haproxy']['global_max_connections'] %>
-  #debug
-  #quiet
+  <%= node['haproxy']['debug_options'] %>
+
   user <%= node['haproxy']['user'] %>
   group <%= node['haproxy']['group'] %>
 <% if node['haproxy']['enable_stats_socket'] -%>


### PR DESCRIPTION
- CentOS7 compatibiliy
  - Use poise-service to manage both systemd and upstart
  - Update metadata
  - Update Cheffile
- Update kitchen.yml
  - Add debian for sysvinit compliance
  - Add suites for source installation
  - Use of anchor
  - Add CentOS 7
  - Correct typo
  - Exclude debian7 for package installation
- Correct global_options error with kitchen
  - Add new attribute debug_options
  - Correct template file
  - Correct kitchen.y
