### PR TITLE
Don't use cloud attributes to discover ips

### DIFF
--- a/recipes/_discovery.rb
+++ b/recipes/_discovery.rb
@@ -26,18 +26,7 @@ pool_members << node if node.run_list.roles.include?(node['haproxy']['app_server
 # pool members are in the same cloud
 # TODO refactor this logic into library...see COOK-494
 pool_members.map! do |member|
-  server_ip = begin
-    if member.attribute?('cloud')
-      if node.attribute?('cloud') && (member['cloud']['provider'] == node['cloud']['provider'])
-         member['cloud']['local_ipv4']
-      else
-        member['cloud']['public_ipv4']
-      end
-    else
-      member['ipaddress']
-    end
-  end
-  {:ipaddress => server_ip, :hostname => member['hostname']}
+  {:ipaddress => member['ipaddress'], :hostname => member['hostname']}
 end
 
 pool_members.sort! do |a,b|


### PR DESCRIPTION
Cloud attributes don't have a consistent structure among the different cloud providers. For example:
- In Google Compute engine, `cloud['local_ipv4']` and `cloud['public_ipv4']` are lists of ip addresses (or lists with a single element).
- In DigitalOcean they are hashes that contain an _ipaddress_ key with the node's address as a value.

Given that there isn't (yet) a consistent structure for the cloud namespace, this change reverts its use and just reads the `node['ipaddress']` value. It is not the best approach as it might get the public address, but it is better to have a working one than a broken one.

A proper fix should include reading the `cloud['provider']` value and use it to properly parse the contents of the `cloud['local_ipv4']` and `cloud['public_ipv4']` objects.
