### PR TITLE
Allow server startup from app_lb recipe.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the haproxy cookbook. (@sun77)
 
+## v3.0.2 (tbc)
+
+- Allow server startup from `app_lb` recipe. [#171][]
+
 ## v3.0.1 (2017-1-30)
 
 - Reload haproxy configuration on changes [#152][]

--- a/recipes/app_lb.rb
+++ b/recipes/app_lb.rb
@@ -60,6 +60,19 @@ if node['haproxy']['enable_ssl']
   end
 end
 
+cookbook_file '/etc/default/haproxy' do
+  source 'haproxy-default'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create
+  notifies :restart, 'service[haproxy]', :delayed
+end
+
 haproxy_config 'Create haproxy.cfg' do
   notifies :restart, 'service[haproxy]', :delayed
+end
+
+service 'haproxy' do # Dummy resource for restarting on config updates
+  action :nothing
 end


### PR DESCRIPTION
In version 3.0 of the cookbook, the `app_lb` recipe is broken when installing from a package, as the service declaration formerly in `install_package` has been removed from the resource bundle. This change replaces it, thus avoiding the following error:

```
ERROR: resource haproxy_config[Create haproxy.cfg] is configured to notify resource service[haproxy] with action restart, but service[haproxy] cannot be found in the resource collection. haproxy_config[Create haproxy.cfg] is defined in /tmp/kitchen/cache/cookbooks/haproxy/recipes/app_lb.rb:63:in `from_file'
```

Additionally, installation via the `manual` recipe replaces the file `/etc/default/haproxy`, which on Ubuntu systems contains an `ENABLED=0` by default that prevents the service from starting up. The version of this file deployed by the cookbook updates it to `ENABLED=1`, so that haproxy can start up, but this is not performed in an `app_lb` installation.

This is an MVP to get the `app_lb` recipe back to a useful state. I'm open to any better suggestions on how to implement fixes.