### PR TITLE
chef_version requires Chef >= 12.6.0.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -19,4 +19,4 @@ depends           'poise-service'
 
 source_url 'https://github.com/sous-chefs/haproxy'
 issues_url 'https://github.com/sous-chefs/haproxy/issues'
-chef_version '>= 12.1'
+chef_version '>= 12.1' if respond_to?(:chef_version)


### PR DESCRIPTION
The `chef_version` property was introduced in 12.6.0, so this cookbook will error on some Chefs which are otherwise compatible.

There is also an edge case where older versions of Berkshelf will error, even if used with Chef >= 12.6, if the haproxy cookbook is fetched from source rather than Supermarket, due to a dependency on a version of Ridley without support for `chef_version`.