### PR TITLE
Fix bug introduced in #174

### DIFF
--- a/providers/lb.rb
+++ b/providers/lb.rb
@@ -13,7 +13,7 @@ action :create do
       end
     end
   else
-    listener << "bind #{new_resource.bind}"
+    listener << "bind #{new_resource.bind}" unless new_resource.bind.nil?
   end
   listener << "balance #{new_resource.balance}" unless new_resource.balance.nil?
   listener << "mode #{new_resource.mode}" unless new_resource.mode.nil?


### PR DESCRIPTION
This fixes a bug that was introduced in #174 which doesn't honor the fact if the
bind parameter is nil don't include any bind line. In our case, we put in the
bind keyword in the parameters parameter so this added two bind statements and
made haproxy unhappy.

It looks like this was a copypasta originally as this was included in the prior
code.

### Description

Returns to previous behavior when the bind parameter is nil, don't include any bind keyword statements.

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable