### PR TITLE
Provide separate SSL pool member capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Installs haproxy and prepares the configuration location.
     "ssl_port" => 4001
   }]
   ```
-
+- `node['haproxy']['ssl_members']` - used by the manual recipe to create a seperate member pool for the SSL listener. Opitional. Defaults to `node['haproxy']['members']`
+- `node['haproxy']['ssl_pool_members_option']` - used by the manual recipe to define member options for the SSL member pool. Optional. Defaults to `node['haproxy']['pool_members_option']`
 - `node['haproxy']['member_port']` - the port that member systems will be listening on if not otherwise specified in the members attribute, default 8080
 - `node['haproxy']['member_weight']` - the weight to apply to member systems if not otherwise specified in the members attribute, default 1
 - `node['haproxy']['app_server_role']` - used by the `app_lb` recipe to search for a specific role of member systems. Default `webserver`.

--- a/recipes/manual.rb
+++ b/recipes/manual.rb
@@ -82,8 +82,9 @@ if node['haproxy']['enable_ssl']
   pool = ['option ssl-hello-chk']
   pool << "option httpchk #{conf['ssl_httpchk']}" if conf['ssl_httpchk']
   pool << "cookie #{node['haproxy']['cookie']}" if node['haproxy']['cookie']
-  servers = node['haproxy']['members'].map do |member|
-    "#{member['hostname']} #{member['ipaddress']}:#{member['ssl_port'] || ssl_member_port} weight #{member['weight'] || member_weight} maxconn #{member['max_connections'] || member_max_conn} check #{node['haproxy']['pool_members_option']}"
+  member_pool = node['haproxy']['ssl_members'] || node['haproxy']['members']
+  servers = member_pool.map do |member|
+    "#{member['hostname']} #{member['ipaddress']}:#{member['ssl_port'] || ssl_member_port} weight #{member['weight'] || member_weight} maxconn #{member['max_connections'] || member_max_conn} check #{node['haproxy']['ssl_pool_members_option'] || node['haproxy']['pool_members_option']}"
   end
   haproxy_lb 'servers-https' do
     type 'backend'


### PR DESCRIPTION
### Description

This change allows different members to be defined in the SSL pool via the node['haproxy']['ssl_members'] attribute . The default behavior is to use the node['haproxy']['members'] attribute, if no node['haproxy']['ssl_members'] are defined.

### Contribution Check List

- [ *] All tests pass.
- [ ] New functionality includes testing.
- [ *] New functionality has been documented in the README if applicable