### PR TITLE
Fix backend config missing space and empty servers array

### DIFF
--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -81,10 +81,12 @@ frontend <%= frontend %>
 <% if !@backend.nil? %>
 <% @backend.each do | key, listeners | %>
 backend <%= key %>
+  <% if !listeners['server'].nil? %>
   <% listeners['server'].each do | s |%>
     <% s.each  do |server|%>
   server <%= server %>
     <% end -%>
+  <% end -%>
   <% end -%>
   <% if !listeners['acl'].nil? %>
   <% listeners['acl'].each do | acl |%>

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -103,7 +103,7 @@ backend <%= key %>
 
   <% if !listeners['extra_options'].nil? %>
   <% listeners['extra_options'].each do | key, value |%>
-  <%= key %><%= value %>
+  <%= key %> <%= value %>
   <% end -%>
   <% end -%>
 <% end # backend loop -%>

--- a/test/fixtures/cookbooks/test/recipes/config_2.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_2.rb
@@ -58,3 +58,7 @@ haproxy_backend 'tiles_public' do
      ]
   extra_options 'stick-table' => 'type ip size 200k expire 2m store conn_rate(60s),bytes_out_rate(60s)'
 end
+
+haproxy_backend 'abuser' do
+  extra_options 'errorfile' => '403 /etc/haproxy/errors/403.http'
+end

--- a/test/fixtures/cookbooks/test/recipes/config_2.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_2.rb
@@ -35,7 +35,7 @@ haproxy_frontend 'http' do
   acl ['kml_request path_reg -i /kml/',
        'bbox_request path_reg -i /bbox/',
        'gina_host hdr(host) -i foo.bar.com',
-       'rhost_host hdr(host) -i dave.foo.bar.com foo.foo.com',
+       'rrhost_host hdr(host) -i dave.foo.bar.com foo.foo.com',
        'source_is_abuser src_get_gpc0(http) gt 0',
        'tile_host hdr(host) -i -f /etc/haproxy/tile_domains.lst',
        'authorized_network src -f /etc/haproxy/authorized_networks.lst',
@@ -43,18 +43,18 @@ haproxy_frontend 'http' do
        'authorized_token urlp(GOGC) -i -f /etc/haproxy/authorized_tokens.lst',
   ]
   extra_options 'stick-table' => 'type ip size 200k expire 10m store gpc0',
-                'tcp-request' => 'connection track-sc1 src if ! source_is_abuser'
+                'tcp-request' => 'connection track-sc1 src if !source_is_abuser'
 end
 
 haproxy_backend 'tiles_public' do
   server ['tile0 10.0.0.10:80 check weight 1 maxconn 100',
-          'tile1 10.0.0.10:80 check weight 1 maxconn 100']
+          'tile1 10.0.0.11:80 check weight 1 maxconn 100']
   tcp_request ['track-sc2 src',
                'reject if conn_rate_abuse !authorized_network mark_as_abuser']
-  acl ['authorized_network	src	-f /etc/haproxy/authorized_networks.lst',
+  acl ['authorized_network src -f /etc/haproxy/authorized_networks.lst',
        'conn_rate_abuse sc2_conn_rate gt 3000',
        'data_rate_abuse sc2_bytes_out_rate gt 20000000',
        'mark_as_abuser sc1_inc_gpc0 gt 0',
      ]
-  extra_options 'stick-table' => 'type ip   size 200k   expire 2m  store conn_rate(60s),bytes_out_rate(60s)'
+  extra_options 'stick-table' => 'type ip size 200k expire 2m store conn_rate(60s),bytes_out_rate(60s)'
 end

--- a/test/fixtures/cookbooks/test/recipes/config_2.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_2.rb
@@ -48,7 +48,7 @@ end
 
 haproxy_backend 'tiles_public' do
   server ['tile0 10.0.0.10:80 check weight 1 maxconn 100',
-          'tile1 10.0.0.11:80 check weight 1 maxconn 100']
+          'tile1 10.0.0.10:80 check weight 1 maxconn 100']
   tcp_request ['track-sc2 src',
                'reject if conn_rate_abuse !authorized_network mark_as_abuser']
   acl ['authorized_network src -f /etc/haproxy/authorized_networks.lst',

--- a/test/integration/config_2/example_spec.rb
+++ b/test/integration/config_2/example_spec.rb
@@ -29,4 +29,7 @@ describe file('/etc/haproxy/haproxy.cfg') do
   its('content') { should match /reject if conn_rate_abuse !authorized_network mark_as_abuser/ }
   its('content') { should match /tile0 10.0.0.10:80 check weight 1 maxconn 100/ }
   its('content') { should match /tile1/ }
+
+  its('content') { should match(/backend abuser/) }
+  its('content') { should match(%r{errorfile 403 /etc/haproxy/errors/403.http}) }
 end

--- a/test/integration/config_2/example_spec.rb
+++ b/test/integration/config_2/example_spec.rb
@@ -17,17 +17,17 @@ describe file('/etc/haproxy/haproxy.cfg') do
   its('content') { should match(/timeout connect 5s/) }
   its('content') { should match(/stick-table type ip size 200k expire 10m store gpc0/) }
   its('content') { should match(%r{acl kml_request path_reg -i /kml}) }
-  its('content') { should match(%r{acl bbox_request path_reg	-i /bbox}) }
-  its('content') { should match(/acl gina_host hdr(host) -i foo.bar.com/) }
-  its('content') { should match(/acl rrhost_host hdr(host) -i dave.foo.bar.com foo.foo.com/) }
-  its('content') { should match(/acl rrhost_host hdr(host) -i dave.foo.bar.com foo.foo.com/) }
-  its('content') { should match(%r{acl tile_host hdr(host) -i -f /etc/haproxy/tile_domains.lst}) }
-  its('content') { should match(/tcp-request connection track-sc1 src if ! source_is_abuser/) }
+  its('content') { should match(%r{acl bbox_request path_reg -i /bbox}) }
+  its('content') { should match(/acl gina_host hdr\(host\) -i foo.bar.com/) }
+  its('content') { should match(/acl rrhost_host hdr\(host\) -i dave.foo.bar.com foo.foo.com/) }
+  its('content') { should match(%r{acl tile_host hdr\(host\) -i -f /etc/haproxy/tile_domains.lst}) }
+  its('content') { should match(/tcp-request connection track-sc1 src if !source_is_abuser/) }
   # Tiles Public
   its('content') { should match(/backend tiles_public/) }
   its('content') { should match /conn_rate_abuse sc2_conn_rate gt 3000/ }
   its('content') { should match /data_rate_abuse sc2_bytes_out_rate gt 20000000/ }
   its('content') { should match /reject if conn_rate_abuse !authorized_network mark_as_abuser/ }
   its('content') { should match /tile0 10.0.0.10:80 check weight 1 maxconn 100/ }
+  its('content') { should match /tile1 10.0.0.11:80 check weight 1 maxconn 100/ }
   its('content') { should match /tile1/ }
 end

--- a/test/integration/config_2/example_spec.rb
+++ b/test/integration/config_2/example_spec.rb
@@ -28,6 +28,5 @@ describe file('/etc/haproxy/haproxy.cfg') do
   its('content') { should match /data_rate_abuse sc2_bytes_out_rate gt 20000000/ }
   its('content') { should match /reject if conn_rate_abuse !authorized_network mark_as_abuser/ }
   its('content') { should match /tile0 10.0.0.10:80 check weight 1 maxconn 100/ }
-  its('content') { should match /tile1 10.0.0.11:80 check weight 1 maxconn 100/ }
   its('content') { should match /tile1/ }
 end


### PR DESCRIPTION
### Description

Fixes issue with missing space in `extra_options` resource for haproxy backends
Fixes issue with backends that don't have any servers (use case would be to serve out static error file)

### Issues Resolved

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable