### PR TITLE
Notify restart haproxy from the main template resource.

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -107,7 +107,8 @@ action :create do
       group new_resource.haproxy_group
       mode '0644'
       cookbook 'haproxy'
-      notifies :restart, 'poise_service[haproxy]', :immediately
+      notifies :enable, 'poise_service[haproxy]', :immediately
+      notifies :restart, 'poise_service[haproxy]', :delayed
       variables()
       action :nothing
       delayed_action :nothing

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -107,7 +107,7 @@ action :create do
       group new_resource.haproxy_group
       mode '0644'
       cookbook 'haproxy'
-      notifies :enable, 'poise_service[haproxy]', :immediately
+      notifies :restart, 'poise_service[haproxy]', :immediately
       variables()
       action :nothing
       delayed_action :nothing


### PR DESCRIPTION
This change will only notify the haproxy service to restart should one
of the sub resources change it's config e.g. a port.
Closes #197
