### PR TITLE
Multiple addresses and ports on listener and frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 ## [v4.0.1] (20-04-2017)
 - Updating README.md
 - Adding compat_resource for chef-12 support
-- Improved rendering of the configuration file [#96]
+- Improved rendering of the configuration file [#196]
 
 ## [v4.0.0] (18-04-2017)
 - COMPATIBILIY WARNING!!!! This version removes the existing recipes, attributes, and instance provider in favor of the new

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache 2.0'
 description       'Installs and configures haproxy'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.0.2'
+version           '4.0.3'
 source_url        'https://github.com/sous-chefs/haproxy'
 issues_url        'https://github.com/sous-chefs/haproxy/issues'
 chef_version      '>= 12.5' if respond_to?(:chef_version)

--- a/resources/frontend.rb
+++ b/resources/frontend.rb
@@ -19,17 +19,16 @@ action :create do
       variables['frontend'][new_resource.name] ||= {}
       variables['frontend'][new_resource.name]['default_backend'] ||= ''
       variables['frontend'][new_resource.name]['default_backend'] << new_resource.default_backend
+      variables['frontend'][new_resource.name]['bind'] = []
       if new_resource.bind.is_a? Hash
-        variables['frontend'][new_resource.name]['bind'] = []
         new_resource.bind.map do |addresses, ports|
           addresses = Array(addresses) unless addresses.is_a? Array
           ports = Array(ports) unless ports.is_a? Array
           (Array(addresses).product Array(ports)).each do |combo|
-            variables['frontend'][new_resource.name]['bind'] << "#{combo.join(':')}"
+            variables['frontend'][new_resource.name]['bind'] << combo.join(':')
           end
         end
       else
-        variables['frontend'][new_resource.name]['bind'] ||= []
         variables['frontend'][new_resource.name]['bind'] << new_resource.bind
       end
       variables['frontend'][new_resource.name]['maxconn'] ||= ''

--- a/resources/frontend.rb
+++ b/resources/frontend.rb
@@ -22,8 +22,6 @@ action :create do
       variables['frontend'][new_resource.name]['bind'] = []
       if new_resource.bind.is_a? Hash
         new_resource.bind.map do |addresses, ports|
-          addresses = Array(addresses) unless addresses.is_a? Array
-          ports = Array(ports) unless ports.is_a? Array
           (Array(addresses).product Array(ports)).each do |combo|
             variables['frontend'][new_resource.name]['bind'] << combo.join(':')
           end

--- a/resources/listen.rb
+++ b/resources/listen.rb
@@ -22,17 +22,16 @@ action :create do
       variables['listen'][new_resource.name] ||= {}
       variables['listen'][new_resource.name]['mode'] ||= ''
       variables['listen'][new_resource.name]['mode'] << new_resource.mode
+      variables['listen'][new_resource.name]['bind'] ||= []
       if new_resource.bind.is_a? Hash
-        variables['listen'][new_resource.name]['bind'] = []
         new_resource.bind.map do |addresses, ports|
           addresses = Array(addresses) unless addresses.is_a? Array
           ports = Array(ports) unless ports.is_a? Array
           (Array(addresses).product Array(ports)).each do |combo|
-            variables['listen'][new_resource.name]['bind'] << "#{combo.join(':')}"
+            variables['listen'][new_resource.name]['bind'] << combo.join(':')
           end
         end
       else
-        variables['listen'][new_resource.name]['bind'] ||= []
         variables['listen'][new_resource.name]['bind'] << new_resource.bind
       end
       variables['listen'][new_resource.name]['maxconn'] ||= ''

--- a/resources/listen.rb
+++ b/resources/listen.rb
@@ -25,8 +25,6 @@ action :create do
       variables['listen'][new_resource.name]['bind'] ||= []
       if new_resource.bind.is_a? Hash
         new_resource.bind.map do |addresses, ports|
-          addresses = Array(addresses) unless addresses.is_a? Array
-          ports = Array(ports) unless ports.is_a? Array
           (Array(addresses).product Array(ports)).each do |combo|
             variables['listen'][new_resource.name]['bind'] << combo.join(':')
           end

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -83,7 +83,9 @@ userlist <%= userlist %>
 frontend <%= frontend %>
   default_backend <%= f['default_backend'] %>
 <% unless f['bind'].empty? -%>
-  bind <%= f['bind'] %>
+<% f['bind'].each do |binding| -%>
+  bind <%= binding %>
+<% end -%>
 <% end -%>
 <% unless f['maxconn'].empty? -%>
   maxconn <%= f['maxconn'] %>
@@ -155,7 +157,11 @@ backend <%= key %>
 
 listen <%= key %>
   mode <%= listen['mode']%>
-  bind <%= listen['bind']%>
+<% unless listen['bind'].empty? -%>
+<% listen['bind'].each do |binding| -%>
+  bind <%= binding %>
+<% end -%>
+<% end -%>
   maxconn <%= listen['maxconn']%>
   stats uri <%= listen['stats_uri']%>
 <% if listen['http_request'] -%>

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -82,10 +82,8 @@ userlist <%= userlist %>
 
 frontend <%= frontend %>
   default_backend <%= f['default_backend'] %>
-<% unless f['bind'].empty? -%>
 <% f['bind'].each do |binding| -%>
   bind <%= binding %>
-<% end -%>
 <% end -%>
 <% unless f['maxconn'].empty? -%>
   maxconn <%= f['maxconn'] %>
@@ -157,10 +155,8 @@ backend <%= key %>
 
 listen <%= key %>
   mode <%= listen['mode']%>
-<% unless listen['bind'].empty? -%>
 <% listen['bind'].each do |binding| -%>
   bind <%= binding %>
-<% end -%>
 <% end -%>
   maxconn <%= listen['maxconn']%>
   stats uri <%= listen['stats_uri']%>

--- a/test/fixtures/cookbooks/test/recipes/config_1.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_1.rb
@@ -25,8 +25,10 @@ haproxy_frontend 'http-in' do
   default_backend 'servers'
 end
 
+bind_hash = { '*' => '8080', '0.0.0.0' => %w(8081 8180) }
+
 haproxy_frontend 'multiport' do
-  bind ({'*' => '8080', '0.0.0.0' => ['8081', '8180']})
+  bind bind_hash
   default_backend 'servers'
 end
 

--- a/test/fixtures/cookbooks/test/recipes/config_1.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_1.rb
@@ -25,6 +25,11 @@ haproxy_frontend 'http-in' do
   default_backend 'servers'
 end
 
+haproxy_frontend 'multiport' do
+  bind ({'*' => '8080', '0.0.0.0' => ['8081', '8180']})
+  default_backend 'servers'
+end
+
 haproxy_backend 'servers' do
   server ['server1 127.0.0.1:8000 maxconn 32']
 end

--- a/test/integration/config_1/example_spec.rb
+++ b/test/integration/config_1/example_spec.rb
@@ -16,7 +16,11 @@ describe file('/etc/haproxy/haproxy.cfg') do
   its('content') { should match(/daemon/) }
   its('content') { should match(/timeout connect 5000ms/) }
   its('content') { should match(/frontend http-in/) }
+  its('content') { should match(/frontend multiport/) }
   its('content') { should match(/bind \*:80/) }
+  its('content') { should match(/bind \*:8080/) }
+  its('content') { should match(/bind 0.0.0.0:8081/) }
+  its('content') { should match(/bind 0.0.0.0:8180/) }
   its('content') { should match(/backend servers/) }
   its('content') { should match(/server server1 127.0.0.1:8000 maxconn 32/) }
 end


### PR DESCRIPTION
Added capacity to understand multiple addresses and ports with hash for 'bind' attribute of haproxy_lb resource.
Managed at the same time both String and Array.
Multiple: `bind ({addresses => ports})` Hash
Single: `bind "address:port"` String

**Example**
_Attributes_
```
default['haproxy']['frontend']['bind'] = {'127.0.0.1' => [80,81], '0.0.0.0'=>[80,81]}
```
_Resource_
```
haproxy_frontend "test" do
    bind node['haproxy']['frontend']['bind']
    acl ...
    use_backend ...
    default_backend ...
    extra_options ...
end
```

_Results_
```
frontend test
  bind 127.0.0.1:80
  bind 127.0.0.1:81
  bind 0.0.0.0:80
  bind 0.0.0.0:81
  acl ...
  use_backend test if ...
  default_backend ...
```

**Other Examples**
_Resources_
```
haproxy_listen "test" do
    bind ({'*' => ['8080', '8181'], '127.0.0.1' => '80']})`
    stats_uri ....
end
```

_Results_
```
listen test
  bind *:8080
  bind *:8181
  bind 127.0.0.1:80
  stats uri ...
```