### PR TITLE
208 stats as hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 ## Unreleased
 
+- BREAKING CHANGES: This version removes some stat related properties from the `haproxy_global` and `haproxy_listen` resources in favor of using a hash for configuration options.
+
 ## [v4.1.0]
 - Adding userlist resource, to see usage: `test/fixtures/cookbooks/test/recipes/config_1_userlist.rb`
 - fixing haproxy_retries in haproxy_config_defaults resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 This file is used to list changes made in each version of the haproxy cookbook.
 
 ## Unreleased
+
+## [v4.1.0]
 - Adding userlist resource, to see usage: `test/fixtures/cookbooks/test/recipes/config_1_userlist.rb`
 - fixing haproxy_retries in haproxy_config_defaults resource
 - updating source install test to take node attributes as haproxy.org is slow.
 - added chef-search example in: `test/fixtures/cookbooks/test/recipes/config_backend_search.rb`
+- Multiple addresses and ports on listener and frontend #205
 
 ## [v4.0.2] (21-04-2017)
 - Fix haproxy service start on Ubuntu 14.04 #199
@@ -245,7 +248,8 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 - Use `node.chef_environment` instead of `node['app_environment']`
 
-[Unreleased]: https://github.com/sous-chefs/haproxy/compare/v4.0.2...HEAD
+[Unreleased]: https://github.com/sous-chefs/haproxy/compare/v4.1.0...HEAD
+[v4.1.0]: https://github.com/sous-chefs/haproxy/compare/v4.0.2...v4.1.0
 [v4.0.2]: https://github.com/sous-chefs/haproxy/compare/v4.0.1...v4.0.2
 [v4.0.1]: https://github.com/sous-chefs/haproxy/compare/v4.0.0...v4.0.1
 [v4.0.0]: https://github.com/sous-chefs/haproxy/compare/v3.0.4...v4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 ## Unreleased
 
-- BREAKING CHANGES: This version removes some stat related properties from the `haproxy_global` and `haproxy_listen` resources in favor of using a hash for configuration options.
+- BREAKING CHANGES: This version removes `stats_socket`, `stats_uri` and `stats_timeout` properties from the `haproxy_global` and `haproxy_listen` resources in favor of using a hash to pass configuration options.
 
 ## [v4.1.0]
 - Adding userlist resource, to see usage: `test/fixtures/cookbooks/test/recipes/config_1_userlist.rb`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ haproxy_config_global '' do
   log '/dev/log local0'
   log_tag 'WARDEN'
   pidfile '/var/run/haproxy.pid'
-  stats_socket '/var/lib/haproxy/stats level admin'
+  stats socket: '/var/lib/haproxy/stats level admin'
   tuning 'bufsize' => '262144'
 end
 ```

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name              'haproxy'
 maintainer        'Sous Chefs'
 maintainer_email  'help@sous-chefs.org'
-license           'Apache 2.0'
+license           'Apache-2.0'
 description       'Installs and configures haproxy'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           '4.1.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache 2.0'
 description       'Installs and configures haproxy'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.0.3'
+version           '4.1.0'
 source_url        'https://github.com/sous-chefs/haproxy'
 issues_url        'https://github.com/sous-chefs/haproxy/issues'
 chef_version      '>= 12.5' if respond_to?(:chef_version)

--- a/resources/config_defaults.rb
+++ b/resources/config_defaults.rb
@@ -29,7 +29,7 @@ action :create do
       variables['defaults']['option'] ||= []
       (variables['defaults']['option'] << new_resource.option).flatten!
       variables['defaults']['stats'] ||= {}
-      variables['defaults']['stats'] = new_resource.stats
+      variables['defaults']['stats'].merge!(new_resource.stats)
       variables['defaults']['maxconn'] ||= '' unless new_resource.maxconn.nil?
       variables['defaults']['maxconn'] << new_resource.maxconn.to_s unless new_resource.maxconn.nil?
       variables['defaults']['retries'] ||= '' unless new_resource.haproxy_retries.nil?

--- a/resources/config_global.rb
+++ b/resources/config_global.rb
@@ -4,9 +4,11 @@ property :pidfile, String, default: '/var/run/haproxy.pid'
 property :log, String, default: '/dev/log syslog info'
 property :daemon, [TrueClass, FalseClass], default: true
 property :debug_option, String, default: 'quiet', equal_to: %w(quiet debug)
-property :stats, Hash, default: {
-  socket: lazy { "/var/run/haproxy.sock user #{haproxy_user} group #{haproxy_group}" },
-  timeout: '2m',
+property :stats, Hash, default: lazy {
+  {
+    socket: "/var/run/haproxy.sock user #{haproxy_user} group #{haproxy_group}",
+    timeout: '2m',
+  }
 }
 property :maxconn, Integer, default: 4096
 property :config_cookbook, String, default: 'haproxy'

--- a/resources/config_global.rb
+++ b/resources/config_global.rb
@@ -4,8 +4,10 @@ property :pidfile, String, default: '/var/run/haproxy.pid'
 property :log, String, default: '/dev/log syslog info'
 property :daemon, [TrueClass, FalseClass], default: true
 property :debug_option, String, default: 'quiet', equal_to: %w(quiet debug)
-property :stats_socket, String, default: lazy { "/var/run/haproxy.sock user #{haproxy_user} group #{haproxy_group}" }
-property :stats_timeout, String, default: '2m'
+property :stats, Hash, default: {
+  socket: lazy { "/var/run/haproxy.sock user #{haproxy_user} group #{haproxy_group}" },
+  timeout: '2m',
+}
 property :maxconn, Integer, default: 4096
 property :config_cookbook, String, default: 'haproxy'
 property :chroot, String
@@ -40,10 +42,8 @@ action :create do
       variables['global']['daemon'] << new_resource.daemon.to_s
       variables['global']['debug_option'] ||= ''
       variables['global']['debug_option'] << new_resource.debug_option
-      variables['global']['stats_socket'] ||= ''
-      variables['global']['stats_socket'] << new_resource.stats_socket
-      variables['global']['stats_timeout'] ||= ''
-      variables['global']['stats_timeout'] << new_resource.stats_timeout
+      variables['global']['stats'] ||= {}
+      variables['global']['stats'].merge!(new_resource.stats)
       variables['global']['tuning'] ||= {} unless new_resource.tuning.nil?
       variables['global']['tuning'] = new_resource.tuning unless new_resource.tuning.nil?
       variables['global']['extra_options'] ||= {} unless new_resource.extra_options.nil?

--- a/resources/frontend.rb
+++ b/resources/frontend.rb
@@ -5,6 +5,7 @@ property :default_backend, String, required: true
 property :use_backend, Array
 property :acl, Array
 property :option, Array
+property :stats, Hash, default: {}
 property :extra_options, Hash
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
@@ -29,6 +30,9 @@ action :create do
       else
         variables['frontend'][new_resource.name]['bind'] << new_resource.bind
       end
+      variables['frontend'][new_resource.name]['stats'] ||= {}
+      variables['frontend'][new_resource.name]['stats'].merge!(new_resource.stats)
+
       variables['frontend'][new_resource.name]['maxconn'] ||= ''
       variables['frontend'][new_resource.name]['maxconn'] << new_resource.maxconn.to_s
       variables['frontend'][new_resource.name]['use_backend'] ||= [] unless new_resource.use_backend.nil?

--- a/resources/listen.rb
+++ b/resources/listen.rb
@@ -2,7 +2,7 @@ property :name, String, name_property: true
 property :mode, String, default: 'http', equal_to: %w(http tcp)
 property :bind, [String, Hash], default: '0.0.0.0:80'
 property :maxconn, Integer, default: 2000
-property :stats_uri, String, default: '/'
+property :stats, Hash, default: {}
 property :http_request, String
 property :http_response, String
 property :default_backend, String
@@ -34,8 +34,8 @@ action :create do
       end
       variables['listen'][new_resource.name]['maxconn'] ||= ''
       variables['listen'][new_resource.name]['maxconn'] << new_resource.maxconn.to_s
-      variables['listen'][new_resource.name]['stats_uri'] ||= ''
-      variables['listen'][new_resource.name]['stats_uri'] << new_resource.stats_uri
+      variables['listen'][new_resource.name]['stats'] ||= {}
+      variables['listen'][new_resource.name]['stats'].merge!(new_resource.stats)
       variables['listen'][new_resource.name]['http_request'] ||= '' unless new_resource.http_request.nil?
       variables['listen'][new_resource.name]['http_request'] << new_resource.http_request unless new_resource.http_request.nil?
       variables['listen'][new_resource.name]['http_response'] ||= '' unless new_resource.http_response.nil?

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -16,8 +16,9 @@ global
   daemon
 <% end -%>
   <%= @global['debug_option'] %>
-  stats socket <%= @global['stats_socket'] %>
-  stats timeout <%= @global['stats_timeout'] %>
+<% @global['stats'].each do |option, value| -%>
+  stats <%= option %> <%= value %>
+<% end -%>
 <% if @global['pidfile'] -%>
   pidfile <%= @global['pidfile'] %>
 <% end -%>
@@ -52,10 +53,8 @@ defaults
 <% unless @defaults['retries'].nil? -%>
   retries <%= @defaults['retries'] %>
 <% end -%>
-<% unless @defaults['stats'].nil? %>
-<% @defaults['stats'].each do | key, value | -%>
-  stats <%= key %> <%= value %>
-<% end -%>
+<% @defaults['stats'].each do |option, value| -%>
+  stats <%= option %> <%= value %>
 <% end -%>
 <% unless @defaults['extra_options'].nil? %>
 <% @defaults['extra_options'].each do | option, value | -%>
@@ -71,7 +70,7 @@ userlist <%= userlist %>
 <% i.each do |item| -%>
 <% item.each do |k,v| %>
   <%= type %> <%=k%> <%= v %>
-<% end -%> 
+<% end -%>
 <% end -%>
 <% end -%>
 <% end -%>
@@ -159,7 +158,9 @@ listen <%= key %>
   bind <%= binding %>
 <% end -%>
   maxconn <%= listen['maxconn']%>
-  stats uri <%= listen['stats_uri']%>
+<% listen['stats'].each do |option, value| -%>
+  stats <%= option %> <%= value %>
+<% end -%>
 <% if listen['http_request'] -%>
   http-request <% listen['http_request'] %>
 <% end %>

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -87,6 +87,9 @@ frontend <%= frontend %>
 <% unless f['maxconn'].empty? -%>
   maxconn <%= f['maxconn'] %>
 <% end -%>
+<% f['stats'].each do |option, value| -%>
+  stats <%= option %> <%= value %>
+<% end -%>
 <% unless f['acl'].nil? %>
 <% f['acl'].each do | acl |%>
 <% acl.each do | acl | %>

--- a/test/fixtures/cookbooks/test/recipes/config_1.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_1.rb
@@ -8,7 +8,7 @@ haproxy_config_global '' do
   log '/dev/log local0'
   log_tag 'WARDEN'
   pidfile '/var/run/haproxy.pid'
-  stats_socket '/var/lib/haproxy/stats level admin'
+  stats socket: '/var/lib/haproxy/stats level admin'
   tuning 'bufsize' => '262144'
 end
 

--- a/test/fixtures/cookbooks/test/recipes/config_1_userlist.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_1_userlist.rb
@@ -8,7 +8,7 @@ haproxy_config_global '' do
   log '/dev/log local0'
   log_tag 'WARDEN'
   pidfile '/var/run/haproxy.pid'
-  stats_socket '/var/lib/haproxy/stats level admin'
+  stats socket: '/var/lib/haproxy/stats level admin'
   tuning 'bufsize' => '262144'
 end
 

--- a/test/fixtures/cookbooks/test/recipes/config_2.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_2.rb
@@ -14,8 +14,8 @@ haproxy_config_global 'global' do
   daemon false
   maxconn 4096
   chroot '/var/lib/haproxy'
-  stats_socket '/var/lib/haproxy/haproxy.stat mode 600 level admin'
-  stats_timeout '2m'
+  stats socket: '/var/lib/haproxy/haproxy.stat mode 600 level admin',
+        timeout: '2m'
 end
 
 haproxy_config_defaults 'defaults' do

--- a/test/fixtures/cookbooks/test/recipes/config_2.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_2.rb
@@ -43,6 +43,9 @@ haproxy_frontend 'http' do
        'source_is_abuser src_get_gpc0(http) gt 0',
        'tile_host hdr(host) -i dough.foo.bar.com',
   ]
+
+  stats uri: '/haproxy?stats'
+
   extra_options 'stick-table' => 'type ip size 200k expire 10m store gpc0',
                 'tcp-request' => 'connection track-sc1 src if !source_is_abuser'
 end

--- a/test/fixtures/cookbooks/test/recipes/config_4.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_4.rb
@@ -10,7 +10,7 @@ end
 haproxy_listen 'admin' do
   bind '0.0.0.0:1337'
   mode 'http'
-  stats_uri '/'
-  extra_options 'stats realm' => 'Haproxy-Statistics',
-                'stats auth' => 'user:pwd'
+  stats uri: '/',
+        realm: 'Haproxy-Statistics',
+        auth: 'user:pwd'
 end

--- a/test/fixtures/cookbooks/test/recipes/config_acl.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_acl.rb
@@ -14,8 +14,8 @@ haproxy_config_global 'global' do
   daemon false
   maxconn 4096
   chroot '/var/lib/haproxy'
-  stats_socket '/var/lib/haproxy/haproxy.stat mode 600 level admin'
-  stats_timeout '2m'
+  stats socket: '/var/lib/haproxy/haproxy.stat mode 600 level admin',
+        timeout: '2m'
 end
 
 haproxy_config_defaults 'defaults' do
@@ -101,11 +101,10 @@ end
 haproxy_listen 'admin' do
   bind '0.0.0.0:1337'
   mode 'http'
-  stats_uri '/'
-  extra_options('stats realm' => 'Haproxy-Statistics',
-                'stats auth' => 'user:pwd',
-                'block if restricted_page' => '!network_allowed'
-               )
+  stats uri: '/',
+        realm: 'Haproxy-Statistics',
+        auth: 'user:pwd'
+  extra_options('block if restricted_page' => '!network_allowed')
 end
 
 haproxy_acl 'acls for listen' do

--- a/test/fixtures/cookbooks/test/recipes/config_backend_search.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_backend_search.rb
@@ -8,7 +8,7 @@ haproxy_config_global '' do
   log '/dev/log local0'
   log_tag 'WARDEN'
   pidfile '/var/run/haproxy.pid'
-  stats_socket '/var/lib/haproxy/stats level admin'
+  stats socket: '/var/lib/haproxy/stats level admin'
   tuning 'bufsize' => '262144'
 end
 

--- a/test/integration/config_1/example_spec.rb
+++ b/test/integration/config_1/example_spec.rb
@@ -15,6 +15,8 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should be_grouped_into 'haproxy' }
   its('content') { should match(/daemon/) }
   its('content') { should match(/timeout connect 5000ms/) }
+  its('content') { should match(/stats socket \/var\/lib\/haproxy\/stats level admin/) }
+  its('content') { should match(/stats uri \/haproxy-status/) }
   its('content') { should match(/frontend http-in/) }
   its('content') { should match(/frontend multiport/) }
   its('content') { should match(/bind \*:80/) }

--- a/test/integration/config_1/example_spec.rb
+++ b/test/integration/config_1/example_spec.rb
@@ -15,8 +15,8 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should be_grouped_into 'haproxy' }
   its('content') { should match(/daemon/) }
   its('content') { should match(/timeout connect 5000ms/) }
-  its('content') { should match(/stats socket \/var\/lib\/haproxy\/stats level admin/) }
-  its('content') { should match(/stats uri \/haproxy-status/) }
+  its('content') { should match(%r{stats socket /var/lib/haproxy/stats level admin}) }
+  its('content') { should match(%r{stats uri /haproxy-status}) }
   its('content') { should match(/frontend http-in/) }
   its('content') { should match(/frontend multiport/) }
   its('content') { should match(/bind \*:80/) }

--- a/test/integration/config_2/example_spec.rb
+++ b/test/integration/config_2/example_spec.rb
@@ -16,6 +16,8 @@ describe file('/etc/haproxy/haproxy.cfg') do
   its('content') { should match(/timeout client 50s/) }
   its('content') { should match(/timeout server 50s/) }
   its('content') { should match(/timeout connect 5s/) }
+  its('content') { should match(/stats socket \/var\/lib\/haproxy\/haproxy.stat mode 600 level admin/) }
+  its('content') { should match(/stats timeout 2m/) }
   its('content') { should match(/stick-table type ip size 200k expire 10m store gpc0/) }
   its('content') { should match(%r{acl kml_request path_reg -i /kml}) }
   its('content') { should match(%r{acl bbox_request path_reg -i /bbox}) }

--- a/test/integration/config_2/example_spec.rb
+++ b/test/integration/config_2/example_spec.rb
@@ -16,7 +16,7 @@ describe file('/etc/haproxy/haproxy.cfg') do
   its('content') { should match(/timeout client 50s/) }
   its('content') { should match(/timeout server 50s/) }
   its('content') { should match(/timeout connect 5s/) }
-  its('content') { should match(/stats socket \/var\/lib\/haproxy\/haproxy.stat mode 600 level admin/) }
+  its('content') { should match(%r{stats socket /var/lib/haproxy/haproxy.stat mode 600 level admin}) }
   its('content') { should match(/stats timeout 2m/) }
   its('content') { should match(/stick-table type ip size 200k expire 10m store gpc0/) }
   its('content') { should match(%r{acl kml_request path_reg -i /kml}) }
@@ -24,6 +24,8 @@ describe file('/etc/haproxy/haproxy.cfg') do
   its('content') { should match(/acl gina_host hdr\(host\) -i foo.bar.com/) }
   its('content') { should match(/acl rrhost_host hdr\(host\) -i dave.foo.bar.com foo.foo.com/) }
   its('content') { should match(/tcp-request connection track-sc1 src if !source_is_abuser/) }
+  its('content') { should match(%r{stats uri \/haproxy\?stats}) }
+
   # Tiles Public
   its('content') { should match(/backend tiles_public/) }
   its('content') { should match /conn_rate_abuse sc2_conn_rate gt 3000/ }


### PR DESCRIPTION
### Description

* Removes `stats_socket`, `stats_uri` and `stats_timeout` from the global and listen resources.
* Adds `stats` hash property to global, frontend and listen resources

### Issues Resolved

Resolves #208 

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable