### PR TITLE
Added mode property to backend and frontend resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 ## [unreleased]
 
 * Added Chefspec Matchers for the resources defined in this cookbook.
+* Added `mode` property to `backend` and `frontend` resources.
 
 ## [v4.2.0] (04-05-2017)
 

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -1,4 +1,5 @@
 property :name, String, name_property: true
+property :mode, String, equal_to: %w(http tcp)
 property :server, Array
 property :tcp_request, Array
 property :acl, Array
@@ -14,6 +15,8 @@ action :create do
       cookbook 'haproxy'
       variables['backend'] ||= {}
       variables['backend'][new_resource.name] ||= {}
+      variables['backend'][new_resource.name]['mode'] ||= '' unless new_resource.mode.nil?
+      variables['backend'][new_resource.name]['mode'] << new_resource.mode unless new_resource.mode.nil?
       variables['backend'][new_resource.name]['server'] ||= [] unless new_resource.server.nil?
       variables['backend'][new_resource.name]['server'] << new_resource.server unless new_resource.server.nil?
       variables['backend'][new_resource.name]['tcp_request'] ||= [] unless new_resource.tcp_request.nil?

--- a/resources/frontend.rb
+++ b/resources/frontend.rb
@@ -1,5 +1,6 @@
 property :name, String, name_property: true
 property :bind, [String, Hash], default: '0.0.0.0:80'
+property :mode, String, equal_to: %w(http tcp)
 property :maxconn, Integer, default: 2000
 property :default_backend, String, required: true
 property :use_backend, Array
@@ -30,6 +31,8 @@ action :create do
       else
         variables['frontend'][new_resource.name]['bind'] << new_resource.bind
       end
+      variables['frontend'][new_resource.name]['mode'] ||= '' unless new_resource.mode.nil?
+      variables['frontend'][new_resource.name]['mode'] << new_resource.mode unless new_resource.mode.nil?
       variables['frontend'][new_resource.name]['stats'] ||= {}
       variables['frontend'][new_resource.name]['stats'].merge!(new_resource.stats)
 

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -80,6 +80,9 @@ userlist <%= userlist %>
 <% @frontend.each do |frontend, f | %>
 
 frontend <%= frontend %>
+<% unless f['mode'].nil? -%>
+  mode <%= f['mode'] %>
+<% end -%>
   default_backend <%= f['default_backend'] %>
 <% f['bind'].each do |binding| -%>
   bind <%= binding %>
@@ -119,6 +122,9 @@ frontend <%= frontend %>
 <% @backend.each do | key, backend | %>
 
 backend <%= key %>
+<% unless backend['mode'].nil? -%>
+  mode <%= backend['mode'] %>
+<% end -%>
 <% unless backend['server'].nil? %>
 <% backend['server'].each do | s |%>
 <% s.each  do |server|%>

--- a/test/fixtures/cookbooks/test/recipes/config_1.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_1.rb
@@ -25,6 +25,12 @@ haproxy_frontend 'http-in' do
   default_backend 'servers'
 end
 
+haproxy_frontend 'tcp-in' do
+  mode 'tcp'
+  bind '*:3307'
+  default_backend 'tcp-servers'
+end
+
 bind_hash = { '*' => '8080', '0.0.0.0' => %w(8081 8180) }
 
 haproxy_frontend 'multiport' do
@@ -34,4 +40,9 @@ end
 
 haproxy_backend 'servers' do
   server ['server1 127.0.0.1:8000 maxconn 32']
+end
+
+haproxy_backend 'tcp-servers' do
+  mode 'tcp'
+  server ['server2 127.0.0.1:3306 maxconn 32']
 end

--- a/test/integration/config_1/example_spec.rb
+++ b/test/integration/config_1/example_spec.rb
@@ -25,6 +25,8 @@ describe file('/etc/haproxy/haproxy.cfg') do
   its('content') { should match(/bind 0.0.0.0:8180/) }
   its('content') { should match(/backend servers/) }
   its('content') { should match(/server server1 127.0.0.1:8000 maxconn 32/) }
+  its('content') { should match(/frontend tcp-in\n  mode tcp/) }
+  its('content') { should match(/backend tcp-servers\n  mode tcp/) }
 end
 
 describe service('haproxy') do


### PR DESCRIPTION
### Description

Add a 'mode' property to the frontend and backend resources. Mode is a valid configuration option for HAProxy frontends and backends. See,  http://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-mode

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/haproxy/221)
<!-- Reviewable:end -->
