### PR TITLE
Added 'option' config for backend definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file is used to list changes made in each version of the haproxy cookbook.
 
 ## [unreleased]
+* Added `option` as an Array `property` for `backend` resource. This fixes #234
 
 ## [v4.3.1] (06-13-2017)
 * Adding Oracle Linux 6 support

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -3,6 +3,7 @@ property :mode, String, equal_to: %w(http tcp)
 property :server, Array
 property :tcp_request, Array
 property :acl, Array
+property :option, Array
 property :extra_options, Hash
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
@@ -23,6 +24,8 @@ action :create do
       variables['backend'][new_resource.name]['tcp_request'] << new_resource.tcp_request unless new_resource.tcp_request.nil?
       variables['backend'][new_resource.name]['acl'] ||= [] unless new_resource.acl.nil?
       variables['backend'][new_resource.name]['acl'] << new_resource.acl unless new_resource.acl.nil?
+      variables['backend'][new_resource.name]['option'] ||= [] unless new_resource.option.nil?
+      variables['backend'][new_resource.name]['option'] << new_resource.option unless new_resource.option.nil?
       variables['backend'][new_resource.name]['extra_options'] ||= {} unless new_resource.extra_options.nil?
       variables['backend'][new_resource.name]['extra_options'] = new_resource.extra_options unless new_resource.extra_options.nil?
 

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -142,6 +142,13 @@ backend <%= key %>
   acl <%= acl %>
 <% end -%>
 <% end -%>
+<% unless backend['option'].nil? %>
+<% backend['option'].each do | option |%>
+<% option.each do | option | %>
+  option <%= option %>
+<% end -%>
+<% end -%>
+<% end -%>
 <% unless backend['tcp_request'].nil? %>
 <% backend['tcp_request'].each do | tcp_request |%>
 <% tcp_request.each do | tcp_request | %>

--- a/test/fixtures/cookbooks/test/recipes/config_2.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_2.rb
@@ -55,6 +55,7 @@ haproxy_backend 'tiles_public' do
           'tile1 10.0.0.10:80 check weight 1 maxconn 100']
   tcp_request ['content track-sc2 src',
                'content reject if conn_rate_abuse mark_as_abuser']
+  option %w(httplog dontlognull forwardfor)
   acl ['conn_rate_abuse sc2_conn_rate gt 3000',
        'data_rate_abuse sc2_bytes_out_rate gt 20000000',
        'mark_as_abuser sc1_inc_gpc0 gt 0',

--- a/test/integration/config_2/example_spec.rb
+++ b/test/integration/config_2/example_spec.rb
@@ -39,6 +39,12 @@ describe file('/etc/haproxy/haproxy.cfg') do
   its('content') { should match(%r{errorfile 403 /etc/haproxy/errors/403.http}) }
 end
 
+describe bash('grep -A 12 "^backend tiles_public" /etc/haproxy/haproxy.cfg') do
+  its('stdout') { should match(/option httplog/) }
+  its('stdout') { should match(/option dontlognull/) }
+  its('stdout') { should match(/option forwardfor/) }
+end
+
 describe service('haproxy') do
   it { should be_running }
 end


### PR DESCRIPTION
### Description

`option` is a valid config under backend configuration. Presently we cannot use `extra_options` for adding multiple `option` as it is a Hash. I have resolved this by adding an Array property for backend resource similar to frontend resource.
 
### Issues Resolved

fixes #234

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/haproxy/235)
<!-- Reviewable:end -->
