### PR TITLE
Fix Chef 12 test

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,16 +1,13 @@
 driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
-  chef_version: current
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport:
   name: dokken
 
 provisioner:
   name: dokken
-
-verifier:
-  name: inspec
 
 platforms:
 - name: debian-8

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  require_chef_omnibus: <%= ENV['CHEF_VERSION'] || 'latest' %>
 
 client_rb:
   treat_deprecation_warnings_as_errors: true


### PR DESCRIPTION
The travis job with the CHEF_VERSION env doesn't work; there is no reference to this env var in either kitchen config and the job [installs chef 13](https://travis-ci.org/sous-chefs/haproxy/jobs/249957148#L592), which this PR fixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/haproxy/247)
<!-- Reviewable:end -->
