### PR TITLE
Reload instead of restart on config change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file is used to list changes made in each version of the haproxy cookbook.
 
 ## [unreleased]
+* Reload instead of restart on config change
 
 ## [v4.6.0] (07-13-2017)
 * Re-added `conf_template_source`

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -114,7 +114,7 @@ action :create do
       source lazy { node.run_state['haproxy']['conf_template_source'][config_file] }
       cookbook lazy { node.run_state['haproxy']['conf_cookbook'][config_file] }
       notifies :enable, 'poise_service[haproxy]', :immediately
-      notifies :restart, 'poise_service[haproxy]', :delayed
+      notifies :reload, 'poise_service[haproxy]', :delayed
       variables()
       action :nothing
       delayed_action :nothing

--- a/templates/default/haproxy-init.erb
+++ b/templates/default/haproxy-init.erb
@@ -86,7 +86,8 @@ haproxy_reload()
 {
   check_haproxy_config
 
-  $HAPROXY -f "$CONFIG" -p $PIDFILE -sf $(cat $PIDFILE) -D $EXTRAOPTS \
+  # Specify -sf argument last to support haproxy < 1.6.0
+  $HAPROXY -f "$CONFIG" -p $PIDFILE -D $EXTRAOPTS -sf $(cat $PIDFILE) \
     || return 2
   return 0
 }


### PR DESCRIPTION
### Description

This does a graceful restart which shouldn't disrupt existing connections,
except in rare cases of heavy load (which future haproxy versions will
better address).

https://cbonte.github.io/haproxy-dconv/1.7/management.html#4

### Issues Resolved

N/A

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/haproxy/256)
<!-- Reviewable:end -->
