### PR TITLE
Add option to set haproxy.cfg chmod

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Installs and configures haproxy.
 
 ```ruby
 haproxy_install 'package' do
-
+  conf_file_mode '0640'
 end
 ```
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,6 +1,7 @@
 property :install_type, String, name_property: true, equal_to: %w(package source)
 property :conf_template_source, String, default: 'haproxy.cfg.erb'
 property :conf_cookbook, String, default: 'haproxy'
+property :conf_file_mode, String, default: '0644'
 property :bin_prefix, String, default: '/usr'
 property :config_dir,  String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
@@ -111,7 +112,8 @@ action :create do
     template new_resource.config_file do
       owner new_resource.haproxy_user
       group new_resource.haproxy_group
-      mode '0644'
+      mode new_resource.conf_file_mode
+      sensitive true
       source lazy { node.run_state['haproxy']['conf_template_source'][config_file] }
       cookbook lazy { node.run_state['haproxy']['conf_cookbook'][config_file] }
       unless new_resource.install_only

--- a/test/integration/package/package_spec.rb
+++ b/test/integration/package/package_spec.rb
@@ -7,6 +7,10 @@ describe directory '/etc/haproxy' do
   it { should exist }
 end
 
+describe file '/etc/haproxy/haproxy.cfg' do
+  its(:mode) { should cmp '0644' }
+end
+
 describe service 'haproxy' do
   it { should be_installed }
   it { should be_enabled }

--- a/test/integration/source/source_spec.rb
+++ b/test/integration/source/source_spec.rb
@@ -3,6 +3,10 @@ describe directory '/etc/haproxy' do
   it { should exist }
 end
 
+describe file '/etc/haproxy/haproxy.cfg' do
+  its(:mode) { should cmp '0644' }
+end
+
 describe service 'haproxy' do
   it { should be_installed }
   it { should be_enabled }


### PR DESCRIPTION
### Description

Currently, default chmod is used (0644). Since haproxy.cfg can contain
sensitive data, it is a good idea to give an operator option to pick
what suits him.

By default, it still will be 0644, with an option to change it using
resource attribute.

In addition, I have added sensitive true to haproxy.cfg template.

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/haproxy/266)
<!-- Reviewable:end -->
