### PR TITLE
Fix typo in haproxy.cfg.erb

### DIFF
--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -236,13 +236,13 @@ listen <%= key %>
   stats <%= option %> <%= value %>
 <% end -%>
 <% if listen['http_request'] -%>
-  http-request <% listen['http_request'] %>
+  http-request <%= listen['http_request'] %>
 <% end %>
 <% if listen['http_response'] -%>
-  http-response <% listen['http_response'] %>
+  http-response <%= listen['http_response'] %>
 <% end %>
 <% if listen['default_backend'] -%>
-  default_backend <% listen['default_backend'] %>
+  default_backend <%= listen['default_backend'] %>
 <% end %>
 <% unless listen['acl'].nil? %>
 <% listen['acl'].flatten.uniq.each do | acl |%>

--- a/test/fixtures/cookbooks/test/recipes/config_4.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_4.rb
@@ -13,4 +13,12 @@ haproxy_listen 'admin' do
   stats uri: '/',
         realm: 'Haproxy-Statistics',
         auth: 'user:pwd'
+  http_request 'add-header X-Proto http'
+  http_response 'set-header Expires %[date(3600),http_date]'
+  default_backend 'servers'
+  extra_options('bind-process' => 'odd')
+end
+
+haproxy_backend 'servers' do
+  server ['disabled-server 127.0.0.1:1 disabled']
 end

--- a/test/integration/config_4/example_spec.rb
+++ b/test/integration/config_4/example_spec.rb
@@ -18,6 +18,10 @@ describe file('/etc/haproxy/haproxy.cfg') do
   its('content') { should match(%r{stats uri /}) }
   its('content') { should match(/stats realm Haproxy-Statistics/) }
   its('content') { should match(/stats auth user:pwd/) }
+  its('content') { should match(/http-request add-header X-Proto http/) }
+  its('content') { should match(/http-response set-header Expires \%\[date\(3600\),http_date\]/) }
+  its('content') { should match(/default_backend servers/) }
+  its('content') { should match(/bind-process odd/) }
 end
 
 describe service('haproxy') do


### PR DESCRIPTION
### Description

Fixes typo in `listen` section, makes previously unprintable expressions, printable in `http-request`, `http-response` and `default_backend`.