### PR TITLE
Misc cleanup to the repo

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,6 @@
 driver:
   name: vagrant
 
-
 provisioner:
   name: chef_zero
   product_name: chef
@@ -10,8 +9,6 @@ provisioner:
 
 client_rb:
   treat_deprecation_warnings_as_errors: true
-  resource_cloning: false
-
 verifier:
   name: inspec
 
@@ -26,7 +23,7 @@ platforms:
 - name: fedora-27
 - name: freebsd-10
 - name: freebsd-11
-- name: opensuse-leap-42.2
+- name: opensuse-leap-42
 - name: ubuntu-14.04
 - name: ubuntu-16.04
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'stove'

--- a/chefignore
+++ b/chefignore
@@ -82,6 +82,11 @@ Berksfile.lock
 cookbooks/*
 tmp
 
+# Policyfile #
+##############
+Policyfile.rb
+Policyfile.lock.json
+
 # Cookbooks #
 #############
 CONTRIBUTING*


### PR DESCRIPTION
Remove the Gemfile since stove is built in, use the latest chefignore file, and remove the resource cloning config in the kitchen config now that 13 disables that entirely.