### PR TITLE
add tcplog entry as valid option to

### DIFF
--- a/resources/config_defaults.rb
+++ b/resources/config_defaults.rb
@@ -2,7 +2,7 @@ property :timeout, Hash, default: { client: '10s', server: '10s', connect: '10s'
 property :log, String, default: 'global'
 property :mode, String, default: 'http', equal_to: %w(http tcp)
 property :balance, default: 'roundrobin', equal_to: %w(roundrobin static-rr leastconn first source uri url_param header rdp-cookie)
-property :option, Array, default: %w(httplog dontlognull redispatch)
+property :option, Array, default: %w(httplog dontlognull redispatch tcplog)
 property :stats, Hash, default: { 'uri' => '/haproxy-status' }
 property :maxconn, Integer
 property :extra_options, Hash


### PR DESCRIPTION
### Description

Add `tcplog` as a valid choice to the `haproxy_config_defaults` resource.

Ran into this issue while migrating a legacy install to this cookbook. Here is the [official documentation](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-option%20tcplog) for the format, fwiw.

Reading over [the table](https://github.com/sous-chefs/haproxy/blob/master/example_configs/tablez.md) it appears a bunch of valid `option` entries aren't listed. Should I remove the explicit values to [match the other resources](https://github.com/sous-chefs/haproxy/blob/DEV_GROUP/resources/frontend.rb#L8) that support an `option` array?

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable