### PR TITLE
Fix typo in :source_target_arch property in install.rb

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -18,7 +18,7 @@ property :source_version, String, default: '1.7.8'
 property :source_url, String, default: 'http://www.haproxy.org/download/1.7/src/haproxy-1.7.8.tar.gz'
 property :source_checksum, String, default: 'ec90153ccedd20ad4015d3eaf76b502ff1f61b431d54c22b8457b5784a9ae142'
 property :source_target_cpu, [String, nil], default: lazy { node['kernel']['machine'] }
-property :source_target_arch, [String, nil], deafult: nil
+property :source_target_arch, [String, nil], default: nil
 property :source_target_os, String, default: lazy {
   if node['kernel']['release'].split('.')[0..1].join('.').to_f > 2.6
     @target_os = 'linux2628'


### PR DESCRIPTION
### Description

Fixes the typo in the `:source_target_arch` property in `install.rb`

### Issues Resolved

None?

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable