### PR TITLE
Make bin_prefix reflect in service config (#288)

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -141,6 +141,7 @@ action :create do
                 conf_file: new_resource.config_file,
                 bin_prefix: new_resource.bin_prefix,
                 template: 'haproxy:haproxy.service.erb'
+        action :nothing
       end
     elsif !new_resource.install_only
       poise_service 'haproxy' do
@@ -153,6 +154,7 @@ action :create do
                 run_dir: '/run/haproxy',
                 haproxy_user: new_resource.haproxy_user,
                 haproxy_group: new_resource.haproxy_group
+        action :nothing
       end
 
       cookbook_file '/etc/default/haproxy' do

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -137,8 +137,10 @@ action :create do
                 restart_mode: 'always',
                 after_target: 'network',
                 auto_reload: true,
+                pid_file: '/run/haproxy.pid',
+                conf_file: new_resource.config_file,
+                bin_prefix: new_resource.bin_prefix,
                 template: 'haproxy:haproxy.service.erb'
-        action :nothing
       end
     elsif !new_resource.install_only
       poise_service 'haproxy' do
@@ -151,7 +153,6 @@ action :create do
                 run_dir: '/run/haproxy',
                 haproxy_user: new_resource.haproxy_user,
                 haproxy_group: new_resource.haproxy_group
-        action :nothing
       end
 
       cookbook_file '/etc/default/haproxy' do

--- a/templates/default/haproxy.service.erb
+++ b/templates/default/haproxy.service.erb
@@ -3,10 +3,10 @@ Description=<%= @name %>
 After=syslog.target network.target
 
 [Service]
-Environment="CONFIG=/etc/haproxy/haproxy.cfg" "PIDFILE=/run/haproxy.pid"
-ExecStartPre=/usr/sbin/haproxy -f $CONFIG -c -q
+Environment="CONFIG=<%= @options['conf_file'] -%>" "PIDFILE=<%= @options['pid_file'] -%>"
+ExecStartPre=<%= @options['bin_prefix'] -%>/sbin/haproxy -f $CONFIG -c -q
 ExecStart=<%= @command %>
-ExecReload=/usr/sbin/haproxy -f $CONFIG -c -q
+ExecReload=<%= @options['bin_prefix'] -%>/sbin/haproxy -f $CONFIG -c -q
 ExecReload=/bin/kill -USR2 $MAINPID
 KillSignal=<%= @stop_signal %>
 User=<%= @user %>


### PR DESCRIPTION
### Description

bin_prefix property of haproxy_install resource could be updated when HAProxy was to be built from the source code. SystemD unit file however used a hardcoded path that prevented the newly-built service to be used.


### Issues Resolved

https://github.com/sous-chefs/haproxy/issues/288

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable