### PR TITLE
Release 5.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 ## [unreleased]
 
+## [v5.0.4] (2018-03-28)
+
+- Make 1.8.4 the default installed version (#279)
+- Use dokken docker images
+- Update tests for haproxy service
+- tcplog is now a valid input for the `haproxy_config_defaults` resourcce (#284)
+- bin prefix is now reflexted in the service config. (#288, #289)
+
 ## [v5.0.3] (2018-02-02)
 
 - Fix foodcritic warning for not defining `name_property`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,7 +322,8 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 - Use `node.chef_environment` instead of `node['app_environment']`
 
-[v3.0.0]: https://github.com/sous-chefs/haproxy/compare/v5.0....v5.0.0
+[unreleased]: https://github.com/sous-chefs/haproxy/compare/v5.0.4...HEAD
+[v3.0.0]: https://github.com/sous-chefs/haproxy/compare/v2.0.2...v3.0.0
 [v3.0.1]: https://github.com/sous-chefs/haproxy/compare/v3.0.0...v3.0.1
 [v3.0.2]: https://github.com/sous-chefs/haproxy/compare/v3.0.1...v3.0.2
 [v3.0.3]: https://github.com/sous-chefs/haproxy/compare/v3.0.2...v3.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,3 +342,4 @@ This file is used to list changes made in each version of the haproxy cookbook.
 [v5.0.1]: https://github.com/sous-chefs/haproxy/compare/v5.0.0...v5.0.1
 [v5.0.2]: https://github.com/sous-chefs/haproxy/compare/v5.0.1...v5.0.2
 [v5.0.3]: https://github.com/sous-chefs/haproxy/compare/v5.0.2...v5.0.3
+[v5.0.4]: https://github.com/sous-chefs/haproxy/compare/v5.0.3...v5.0.4

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures haproxy'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '5.0.3'
+version           '5.0.4'
 source_url        'https://github.com/sous-chefs/haproxy'
 issues_url        'https://github.com/sous-chefs/haproxy/issues'
 chef_version      '>= 12.5' if respond_to?(:chef_version)


### PR DESCRIPTION
### Description

Release 5.0.4

Note: this is the last resource that will support Chef 12.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable