### PR TITLE
Use build_essential resource vs. recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ This file is used to list changes made in each version of the haproxy cookbook.
 ### **Breaking changes**
 
 - Adds `haproxy_service` resource see test suites for usage
+- Require Chef 12.20 or later
 
 ### Improvements
 
+- Uses the build_essential resource not the default recipe so the cookbook can be skipped entirely if running on Chef 14+
 - Adds support for haproxy 1.8
 - Simplify the kitchen matrix
 - Remove kitchen.dokken.yml suites and inherit from kitchen.yml

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installs and configures haproxy.
 
 ## Requirements
 
-- Chef 12.5+
+- Chef 12.20+
 
 ### Platforms
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -51,7 +51,7 @@ action :create do
     end
 
   when 'source'
-    include_recipe 'build-essential'
+    build_essential 'compilation tools'
 
     pkg_list = value_for_platform_family(
       'debian' => %w(libpcre3-dev libssl-dev zlib1g-dev),


### PR DESCRIPTION
This allows us to just use the build in resource in Chef 14.

Signed-off-by: Tim Smith <tsmith@chef.io>