### PR TITLE
haproxy_install properties more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 ## [unreleased]
 
+## [v6.2.2] (2018-08-03)
+
+- Made haproxy_install source_url property dynamic with source_version property and removed the need to specify checksum #307
+
 ## [v6.2.1] (2018-08-01)
 
 - Added compiling from source crypt support #305

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures haproxy'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '6.2.1'
+version           '6.2.2'
 source_url        'https://github.com/sous-chefs/haproxy'
 issues_url        'https://github.com/sous-chefs/haproxy/issues'
 chef_version      '>= 12.20'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -17,8 +17,8 @@ property :package_version, [String, nil], default: nil
 
 # Source
 property :source_version, String, default: '1.7.8'
-property :source_url, String, default: 'http://www.haproxy.org/download/1.7/src/haproxy-1.7.8.tar.gz'
-property :source_checksum, String, default: 'ec90153ccedd20ad4015d3eaf76b502ff1f61b431d54c22b8457b5784a9ae142'
+property :source_url, String, default: lazy { "http://www.haproxy.org/download/#{source_version.to_f}/src/haproxy-#{source_version}.tar.gz" }
+property :source_checksum, [String, nil], default: nil
 property :source_target_cpu, [String, nil], default: lazy { node['kernel']['machine'] }
 property :source_target_arch, [String, nil], default: nil
 property :source_target_os, String, default: lazy {
@@ -72,7 +72,7 @@ action :create do
     remote_file 'haproxy source file' do
       path ::File.join(Chef::Config[:file_cache_path], "haproxy-#{new_resource.source_version}.tar.gz")
       source new_resource.source_url
-      checksum new_resource.source_checksum
+      checksum new_resource.source_checksum if new_resource.source_checksum
       action :create
     end
 


### PR DESCRIPTION
### Description

Made haproxy_install source_url property dynamic with source_version property and removed the need to specify checksum. Remote_file resource is already idempotent based on file server modified time for files. This update allows the flexibility to specify the option or not without breaking things.

### Contribution Check List

- [ ] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable