### PR TITLE
removed a couple default values from resources properties 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 ## [v6.2.3] (2018-08-03)
 
-- Removed a few resource default values so they can be specified it the haproxy.cfg default section and added service reload exmample to the readme for config changes
+- Removed a few resource default values so they can be specified in the haproxy.cfg default section and added service reload exmample to the readme for config changes
 
 ## [v6.2.2] (2018-08-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 ## [unreleased]
 
+## [v6.2.3] (2018-08-03)
+
+- Removed a few resource default values so they can be specified it the haproxy.cfg default section and added service reload exmample to the readme for config changes
+
 ## [v6.2.2] (2018-08-03)
 
 - Made `haproxy_install` `source_url` property dynamic with `source_version` property and removed the need to specify checksum #307

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ end
 ### haproxy_service
 
 Installs HAProxy as a systemd or sysvinit service.
+To reload HAProxy service add a subscribes option to the resource block. See example below.
 
 Introduced: v4.0.0
 
@@ -409,6 +410,7 @@ haproxy_service 'haproxy'
 haproxy_service 'haproxy' do
   source_version node['haproxy']['source_version']
   action :create
+  subscribes :reload, 'template[/etc/haproxy/haproxy.cfg]', :immediately
 end
 ```
 ### haproxy_use_backend

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures haproxy'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '6.2.2'
+version           '6.2.3'
 source_url        'https://github.com/sous-chefs/haproxy'
 issues_url        'https://github.com/sous-chefs/haproxy/issues'
 chef_version      '>= 12.20'

--- a/resources/frontend.rb
+++ b/resources/frontend.rb
@@ -1,11 +1,11 @@
 property :bind, [String, Hash], default: '0.0.0.0:80'
 property :mode, String, equal_to: %w(http tcp)
-property :maxconn, Integer, default: 2000
+property :maxconn, Integer
 property :default_backend, String
 property :use_backend, Array
 property :acl, Array
 property :option, Array
-property :stats, Hash, default: {}
+property :stats, Hash
 property :extra_options, Hash
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }

--- a/resources/frontend.rb
+++ b/resources/frontend.rb
@@ -34,11 +34,11 @@ action :create do
       end
       variables['frontend'][new_resource.name]['mode'] ||= '' unless new_resource.mode.nil?
       variables['frontend'][new_resource.name]['mode'] << new_resource.mode unless new_resource.mode.nil?
-      variables['frontend'][new_resource.name]['stats'] ||= {}
-      variables['frontend'][new_resource.name]['stats'].merge!(new_resource.stats)
+      variables['frontend'][new_resource.name]['stats'] ||= {} unless new_resource.stats.nil?
+      variables['frontend'][new_resource.name]['stats'].merge!(new_resource.stats) unless new_resource.stats.nil?
 
-      variables['frontend'][new_resource.name]['maxconn'] ||= ''
-      variables['frontend'][new_resource.name]['maxconn'] << new_resource.maxconn.to_s
+      variables['frontend'][new_resource.name]['maxconn'] ||= '' unless new_resource.maxconn.nil?
+      variables['frontend'][new_resource.name]['maxconn'] << new_resource.maxconn.to_s unless new_resource.maxconn.nil?
       variables['frontend'][new_resource.name]['use_backend'] ||= [] unless new_resource.use_backend.nil?
       variables['frontend'][new_resource.name]['use_backend'] << new_resource.use_backend unless new_resource.use_backend.nil?
       variables['frontend'][new_resource.name]['acl'] ||= [] unless new_resource.acl.nil?

--- a/resources/listen.rb
+++ b/resources/listen.rb
@@ -21,8 +21,8 @@ action :create do
       cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_file] ||= 'haproxy' }
       variables['listen'] ||= {}
       variables['listen'][new_resource.name] ||= {}
-      variables['listen'][new_resource.name]['mode'] ||= ''
-      variables['listen'][new_resource.name]['mode'] << new_resource.mode
+      variables['listen'][new_resource.name]['mode'] ||= '' unless new_resource.mode.nil?
+      variables['listen'][new_resource.name]['mode'] << new_resource.mode unless new_resource.mode.nil?
       variables['listen'][new_resource.name]['bind'] ||= []
       if new_resource.bind.is_a? Hash
         new_resource.bind.map do |addresses, ports|
@@ -33,8 +33,8 @@ action :create do
       else
         variables['listen'][new_resource.name]['bind'] << new_resource.bind
       end
-      variables['listen'][new_resource.name]['maxconn'] ||= ''
-      variables['listen'][new_resource.name]['maxconn'] << new_resource.maxconn.to_s
+      variables['listen'][new_resource.name]['maxconn'] ||= '' unless new_resource.maxconn.nil?
+      variables['listen'][new_resource.name]['maxconn'] << new_resource.maxconn.to_s unless new_resource.maxconn.nil?
       variables['listen'][new_resource.name]['stats'] ||= {} unless new_resource.stats.nil?
       variables['listen'][new_resource.name]['stats'].merge!(new_resource.stats) unless new_resource.stats.nil?
       variables['listen'][new_resource.name]['http_request'] ||= '' unless new_resource.http_request.nil?

--- a/resources/listen.rb
+++ b/resources/listen.rb
@@ -1,6 +1,6 @@
-property :mode, String, default: 'http', equal_to: %w(http tcp)
+property :mode, String, equal_to: %w(http tcp)
 property :bind, [String, Hash], default: '0.0.0.0:80'
-property :maxconn, Integer, default: 2000
+property :maxconn, Integer
 property :stats, Hash
 property :http_request, String
 property :http_response, String

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -26,7 +26,7 @@ global
   daemon
 <% end -%>
   <%= @global['debug_option'] %>
-<% @global['stats'].each do |option, value| -%>
+<% @global['stats']&.each do |option, value| -%>
   stats <%= option %> <%= value %>
 <% end -%>
 <% unless @global['maxconn'].nil? -%>
@@ -96,7 +96,7 @@ defaults
 <% unless @defaults['retries'].nil? -%>
   retries <%= @defaults['retries'] %>
 <% end -%>
-<% @defaults['stats'].each do |option, value| -%>
+<% @defaults['stats']&.each do |option, value| -%>
   stats <%= option %> <%= value %>
 <% end -%>
 <% unless @defaults['extra_options'].nil? %>
@@ -139,10 +139,10 @@ frontend <%= frontend %>
 <% f['bind'].each do |binding| -%>
   bind <%= binding %>
 <% end -%>
-<% unless f['maxconn'].empty? -%>
+<% unless f['maxconn']&.empty? -%>
   maxconn <%= f['maxconn'] %>
 <% end -%>
-<% f['stats'].each do |option, value| -%>
+<% f['stats']&.each do |option, value| -%>
   stats <%= option %> <%= value %>
 <% end -%>
 <% unless f['acl'].nil? %>
@@ -227,12 +227,16 @@ backend <%= key %>
 <% @listen.each do | key, listen |%>
 
 listen <%= key %>
+<% unless listen['mode'].nil? -%>
   mode <%= listen['mode']%>
+<% end -%>
 <% listen['bind'].each do |binding| -%>
   bind <%= binding %>
 <% end -%>
+<% unless listen['maxconn'].nil? -%>
   maxconn <%= listen['maxconn']%>
-<% listen['stats'].each do |option, value| -%>
+<% end -%>
+<% listen['stats']&.each do |option, value| -%>
   stats <%= option %> <%= value %>
 <% end -%>
 <% if listen['http_request'] -%>

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -139,7 +139,7 @@ frontend <%= frontend %>
 <% f['bind'].each do |binding| -%>
   bind <%= binding %>
 <% end -%>
-<% unless f['maxconn']&.empty? -%>
+<% unless f['maxconn'].nil? -%>
   maxconn <%= f['maxconn'] %>
 <% end -%>
 <% f['stats']&.each do |option, value| -%>


### PR DESCRIPTION
### Description

Removed a couple of default values from resource properties and added reload example to haproxy_service section of readme. Default values were removed so if they are defined in the default section of the haproxy.cfg file they can be inherited automatically by listeners, frontends, etc... With property specifying a default then it would put that config piece in the listener even if you intended it to be inherited from the default config section.

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable