### PR TITLE
Add servers property to listener resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 ## [unreleased]
 
+## [v6.2.4] (2018-08-22)
+
+- Added server property to listen resource and config template
+
 ## [v6.2.3] (2018-08-03)
 
 - Removed a few resource default values so they can be specified in the haproxy.cfg default section and added service reload exmample to the readme for config changes

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Introduced: v4.0.0
 - `use_backend` -  (is: Array)
 - `acl` -  (is: Array)
 - `extra_options` -  (is: Hash)
+- `server` -  (is: Array)
 - `config_dir` -  (is: String)
 - `config_file` -  (is: String)
 
@@ -343,6 +344,8 @@ haproxy_listen 'admin' do
   http_response 'set-header Expires %[date(3600),http_date]'
   default_backend 'servers'
   extra_options('bind-process' => 'odd')
+  server ['admin0 10.0.0.10:80 check weight 1 maxconn 100',
+          'admin1 10.0.0.10:80 check weight 1 maxconn 100']
 end
 ```
 ### haproxy_resolver

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures haproxy'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '6.2.4'
+version           '6.2.3'
 source_url        'https://github.com/sous-chefs/haproxy'
 issues_url        'https://github.com/sous-chefs/haproxy/issues'
 chef_version      '>= 12.20'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures haproxy'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '6.2.3'
+version           '6.2.4'
 source_url        'https://github.com/sous-chefs/haproxy'
 issues_url        'https://github.com/sous-chefs/haproxy/issues'
 chef_version      '>= 12.20'

--- a/resources/listen.rb
+++ b/resources/listen.rb
@@ -8,6 +8,7 @@ property :default_backend, String
 property :use_backend, Array
 property :acl, Array
 property :extra_options, Hash
+property :server, Array
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
 
@@ -47,6 +48,8 @@ action :create do
       variables['listen'][new_resource.name]['acl'] << new_resource.acl unless new_resource.acl.nil?
       variables['listen'][new_resource.name]['default_backend'] ||= '' unless new_resource.default_backend.nil?
       variables['listen'][new_resource.name]['default_backend'] << new_resource.default_backend unless new_resource.default_backend.nil?
+      variables['listen'][new_resource.name]['server'] ||= [] unless new_resource.server.nil?
+      variables['listen'][new_resource.name]['server'] << new_resource.server unless new_resource.server.nil?
       variables['listen'][new_resource.name]['extra_options'] ||= {} unless new_resource.extra_options.nil?
       variables['listen'][new_resource.name]['extra_options'] = new_resource.extra_options unless new_resource.extra_options.nil?
 

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -269,6 +269,11 @@ listen <%= key %>
 <% end -%>
 <% end -%>
 <% end -%>
+<% listen['server']&.each do | s |%>
+<% s.each  do |server|%>
+server <%= server %>
+<% end -%>
+<% end -%>
 <% end # listen loop -%>
 <% end # listen -%>
 

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -271,7 +271,7 @@ listen <%= key %>
 <% end -%>
 <% listen['server']&.each do | s |%>
 <% s.each  do |server|%>
-server <%= server %>
+  server <%= server %>
 <% end -%>
 <% end -%>
 <% end # listen loop -%>


### PR DESCRIPTION
### Description

Allows user to specify servers for listeners for simple setups.

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable