### PR TITLE
Move use_backend to bottom of config file

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures haproxy'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '6.2.5'
+version           '6.2.6'
 source_url        'https://github.com/sous-chefs/haproxy'
 issues_url        'https://github.com/sous-chefs/haproxy/issues'
 chef_version      '>= 13.0'

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -150,11 +150,6 @@ frontend <%= frontend %>
   acl <%= acl %>
 <% end -%>
 <% end -%>
-<% unless f['use_backend'].nil? %>
-<% f['use_backend'].flatten.uniq.each do | backend |%>
-  use_backend <%= backend %>
-<% end -%>
-<% end -%>
 <% unless f['option'].nil? %>
 <% f['option'].each do | option |%>
 <% option.each do | option | %>
@@ -171,6 +166,11 @@ frontend <%= frontend %>
 <% else %>
   <%= key %> <%= value %>
 <% end -%>
+<% end -%>
+<% end -%>
+<% unless f['use_backend'].nil? %>
+<% f['use_backend'].flatten.uniq.each do | backend |%>
+  use_backend <%= backend %>
 <% end -%>
 <% end -%>
 <% end # frontend loop -%>
@@ -276,4 +276,3 @@ listen <%= key %>
 <% end -%>
 <% end # listen loop -%>
 <% end # listen -%>
-


### PR DESCRIPTION
### Description
Current cookbook `haproxy.cfg` template outputs the `use_backend` rules before the `extra_options` which can include `http-request` rules. These rules per haproxy config validation, should occur after the `use_backend` rules.
```
$ sudo haproxy -c -V -f /etc/haproxy/haproxy.cfg
[WARNING] ... : parsing [/etc/haproxy/haproxy.cfg:50] : a 'http-request' rule placed after a 'use_backend' rule will still be processed before.
```

This PR just moves the `use_backend` rules after the `extra_options` in the template erb

### Issues Resolved

fixes: #313 

### Contribution Check List

Seeking help on the tests. I am probably being dense, but haven't been able to run tests locally. Attempted following the [linked testing documentation](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD). Could anyone share like a quick list of what it takes to run the tests? The `chef exec bundle install` complains that I don't have a `Gemfile` and the `delivery local unit` complains that I don't have a `local` file.

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable