### PR TITLE
Test for appropriate spacing from start of line and end of line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 ## [unreleased]
 
+- Test for appropriate spacing from start of line and end of line
+
 ## [v6.2.6](2018-11-05)
 
 - Put `http_request` rules before the `use_backend`

--- a/test/integration/config_1/example_spec.rb
+++ b/test/integration/config_1/example_spec.rb
@@ -13,22 +13,22 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should exist }
   it { should be_owned_by 'haproxy' }
   it { should be_grouped_into 'haproxy' }
-  its('content') { should match(/daemon/) }
-  its('content') { should match(/timeout connect 5000ms/) }
-  its('content') { should match(/maxconn 256/) }
-  its('content') { should match(%r{stats socket /var/lib/haproxy/stats level admin}) }
-  its('content') { should match(%r{stats uri /haproxy-status}) }
-  its('content') { should match(/frontend http-in/) }
-  its('content') { should match(/frontend multiport/) }
-  its('content') { should match(/bind \*:80/) }
-  its('content') { should match(/bind \*:8080/) }
-  its('content') { should match(/bind 0.0.0.0:8081/) }
-  its('content') { should match(/bind 0.0.0.0:8180/) }
-  its('content') { should match(/^backend servers/) }
-  its('content') { should match(/default_backend servers/) }
-  its('content') { should match(/server server1 127.0.0.1:8000 maxconn 32/) }
-  its('content') { should match(/frontend tcp-in\n  mode tcp/) }
-  its('content') { should match(/backend tcp-servers\n  mode tcp/) }
+  its('content') { should match(/^  daemon$/) }
+  its('content') { should match(/^  timeout connect 5000ms$/) }
+  its('content') { should match(/^  maxconn 256$/) }
+  its('content') { should match(%r{^  stats socket /var/lib/haproxy/stats level admin$}) }
+  its('content') { should match(%r{^  stats uri /haproxy-status$}) }
+  its('content') { should match(/^frontend http-in$/) }
+  its('content') { should match(/^frontend multiport$/) }
+  its('content') { should match(/^  bind \*:80$/) }
+  its('content') { should match(/^  bind \*:8080$/) }
+  its('content') { should match(/^  bind 0.0.0.0:8081$/) }
+  its('content') { should match(/^  bind 0.0.0.0:8180$/) }
+  its('content') { should match(/^backend servers$/) }
+  its('content') { should match(/^  default_backend servers$/) }
+  its('content') { should match(/^  server server1 127.0.0.1:8000 maxconn 32$/) }
+  its('content') { should match(/^frontend tcp-in\n  mode tcp$/) }
+  its('content') { should match(/^backend tcp-servers\n  mode tcp$/) }
 end
 
 describe service('haproxy') do

--- a/test/integration/config_1_userlist/example_spec.rb
+++ b/test/integration/config_1_userlist/example_spec.rb
@@ -13,18 +13,18 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should exist }
   it { should be_owned_by 'haproxy' }
   it { should be_grouped_into 'haproxy' }
-  its('content') { should match(/daemon/) }
-  its('content') { should match(/timeout connect 5000ms/) }
-  its('content') { should match(/frontend http-in/) }
-  its('content') { should match(/bind \*:80/) }
-  its('content') { should match(/backend servers/) }
-  its('content') { should match(/server server1 127.0.0.1:8000 maxconn 32/) }
-  its('content') { should match(/userlist mylist/) }
-  its('content') { should match(/  group G1 users tiger,scott/) }
-  its('content') { should match(/  group G2 users xdb,scott/) }
-  its('content') { should include '$6$k6y3o.eP$JlKBx9za9667qe4(...)xHSwRv6J.C0/D7cV91' }
-  its('content') { should match(/  user scott insecure-password elgato/) }
-  its('content') { should match(/  user xdb insecure-password hello/) }
+  its('content') { should match(/^  daemon$/) }
+  its('content') { should match(/^  timeout connect 5000ms$/) }
+  its('content') { should match(/^frontend http-in$/) }
+  its('content') { should match(/^  bind \*:80$/) }
+  its('content') { should match(/^backend servers$/) }
+  its('content') { should match(/^  server server1 127.0.0.1:8000 maxconn 32$/) }
+  its('content') { should match(/^userlist mylist$/) }
+  its('content') { should match(/^  group G1 users tiger,scott$/) }
+  its('content') { should match(/^  group G2 users xdb,scott$/) }
+  its('content') { should match(%r{^  user tiger password \$6\$k6y3o\.eP\$JlKBx9za9667qe4\(\.\.\.\)xHSwRv6J\.C0/D7cV91$} ) }
+  its('content') { should match(/^  user scott insecure-password elgato$/) }
+  its('content') { should match(/^  user xdb insecure-password hello$/) }
 end
 
 describe service('haproxy') do

--- a/test/integration/config_1_userlist/example_spec.rb
+++ b/test/integration/config_1_userlist/example_spec.rb
@@ -22,7 +22,7 @@ describe file('/etc/haproxy/haproxy.cfg') do
   its('content') { should match(/^userlist mylist$/) }
   its('content') { should match(/^  group G1 users tiger,scott$/) }
   its('content') { should match(/^  group G2 users xdb,scott$/) }
-  its('content') { should match(%r{^  user tiger password \$6\$k6y3o\.eP\$JlKBx9za9667qe4\(\.\.\.\)xHSwRv6J\.C0/D7cV91$} ) }
+  its('content') { should match(%r{^  user tiger password \$6\$k6y3o\.eP\$JlKBx9za9667qe4\(\.\.\.\)xHSwRv6J\.C0/D7cV91$}) }
   its('content') { should match(/^  user scott insecure-password elgato$/) }
   its('content') { should match(/^  user xdb insecure-password hello$/) }
 end

--- a/test/integration/config_2/example_spec.rb
+++ b/test/integration/config_2/example_spec.rb
@@ -11,38 +11,38 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should exist }
   it { should be_owned_by 'haproxy' }
   it { should be_grouped_into 'haproxy' }
-  its('content') { should_not match(/daemon/) }
+  its('content') { should_not match(/^  daemon/) }
   # Defaults
-  its('content') { should match(/timeout client 50s/) }
-  its('content') { should match(/timeout server 50s/) }
-  its('content') { should match(/timeout connect 5s/) }
-  its('content') { should match(/maxconn 4097/) }
-  its('content') { should match(%r{stats socket /var/lib/haproxy/haproxy.stat mode 600 level admin}) }
-  its('content') { should match(/stats timeout 2m/) }
-  its('content') { should match(/stick-table type ip size 200k expire 10m store gpc0/) }
-  its('content') { should match(%r{acl kml_request path_reg -i /kml}) }
-  its('content') { should match(%r{acl bbox_request path_reg -i /bbox}) }
-  its('content') { should match(/acl gina_host hdr\(host\) -i foo.bar.com/) }
-  its('content') { should match(/acl rrhost_host hdr\(host\) -i dave.foo.bar.com foo.foo.com/) }
-  its('content') { should match(/tcp-request connection track-sc1 src if !source_is_abuser/) }
-  its('content') { should match(%r{stats uri \/haproxy\?stats}) }
+  its('content') { should match(/^  timeout client 50s$/) }
+  its('content') { should match(/^  timeout server 50s$/) }
+  its('content') { should match(/^  timeout connect 5s$/) }
+  its('content') { should match(/^  maxconn 4097$/) }
+  its('content') { should match(%r{^  stats socket /var/lib/haproxy/haproxy.stat mode 600 level admin$}) }
+  its('content') { should match(/^  stats timeout 2m$/) }
+  its('content') { should match(/^  stick-table type ip size 200k expire 10m store gpc0$/) }
+  its('content') { should match(%r{^  acl kml_request path_reg -i /kml/$}) }
+  its('content') { should match(%r{^  acl bbox_request path_reg -i /bbox/$}) }
+  its('content') { should match(/^  acl gina_host hdr\(host\) -i foo.bar.com$/) }
+  its('content') { should match(/^  acl rrhost_host hdr\(host\) -i dave.foo.bar.com foo.foo.com$/) }
+  its('content') { should match(/^  tcp-request connection track-sc1 src if !source_is_abuser$/) }
+  its('content') { should match(%r{^  stats uri \/haproxy\?stats$}) }
 
   # Tiles Public
-  its('content') { should match(/backend tiles_public/) }
-  its('content') { should match(/conn_rate_abuse sc2_conn_rate gt 3000/) }
-  its('content') { should match(/data_rate_abuse sc2_bytes_out_rate gt 20000000/) }
-  its('content') { should match(/reject if conn_rate_abuse mark_as_abuser/) }
-  its('content') { should match(/tile0 10.0.0.10:80 check weight 1 maxconn 100/) }
-  its('content') { should match(/tile1/) }
+  its('content') { should match(/^backend tiles_public$/) }
+  its('content') { should match(/^  acl conn_rate_abuse sc2_conn_rate gt 3000$/) }
+  its('content') { should match(/^  acl data_rate_abuse sc2_bytes_out_rate gt 20000000$/) }
+  its('content') { should match(/^  tcp-request content reject if conn_rate_abuse mark_as_abuser$/) }
+  its('content') { should match(/^  server tile0 10.0.0.10:80 check weight 1 maxconn 100$/) }
+  its('content') { should match(/^  server tile1 10.0.0.10:80 check weight 1 maxconn 100$/) }
 
-  its('content') { should match(/backend abuser/) }
-  its('content') { should match(%r{errorfile 403 /etc/haproxy/errors/403.http}) }
+  its('content') { should match(/^backend abuser$/) }
+  its('content') { should match(%r{^  errorfile 403 /etc/haproxy/errors/403.http$}) }
 end
 
 describe bash('grep -A 12 "^backend tiles_public" /etc/haproxy/haproxy.cfg') do
-  its('stdout') { should match(/option httplog/) }
-  its('stdout') { should match(/option dontlognull/) }
-  its('stdout') { should match(/option forwardfor/) }
+  its('stdout') { should match(/^  option httplog$/) }
+  its('stdout') { should match(/^  option dontlognull$/) }
+  its('stdout') { should match(/^  option forwardfor$/) }
 end
 
 describe service('haproxy') do

--- a/test/integration/config_3/example_spec.rb
+++ b/test/integration/config_3/example_spec.rb
@@ -14,7 +14,7 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should be_owned_by 'haproxy' }
   it { should be_grouped_into 'haproxy' }
 
-  its('content') { should match(/user haproxy/) }
+  its('content') { should match(/  user haproxy/) }
   its('content') { should match(/group haproxy/) }
   its('content') { should match(/quiet/) }
   its('content') { should match(%r{log \/dev\/log local0}) }

--- a/test/integration/config_4/example_spec.rb
+++ b/test/integration/config_4/example_spec.rb
@@ -12,16 +12,16 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should be_owned_by 'haproxy' }
   it { should be_grouped_into 'haproxy' }
 
-  its('content') { should match(/listen admin/) }
-  its('content') { should match(/bind 0.0.0.0:1337/) }
-  its('content') { should match(/mode http/) }
-  its('content') { should match(%r{stats uri /}) }
-  its('content') { should match(/stats realm Haproxy-Statistics/) }
-  its('content') { should match(/stats auth user:pwd/) }
-  its('content') { should match(/http-request add-header X-Proto http/) }
-  its('content') { should match(/http-response set-header Expires \%\[date\(3600\),http_date\]/) }
-  its('content') { should match(/default_backend servers/) }
-  its('content') { should match(/bind-process odd/) }
+  its('content') { should match(/^listen admin$/) }
+  its('content') { should match(/^  bind 0.0.0.0:1337$/) }
+  its('content') { should match(/^  mode http$/) }
+  its('content') { should match(%r{^  stats uri /haproxy-status$}) }
+  its('content') { should match(/^  stats realm Haproxy-Statistics$/) }
+  its('content') { should match(/^  stats auth user:pwd$/) }
+  its('content') { should match(/^  http-request add-header X-Proto http$/) }
+  its('content') { should match(/^  http-response set-header Expires \%\[date\(3600\),http_date\]$/) }
+  its('content') { should match(/^  default_backend servers$/) }
+  its('content') { should match(/^  bind-process odd$/) }
 end
 
 describe service('haproxy') do

--- a/test/integration/config_acl/example_spec.rb
+++ b/test/integration/config_acl/example_spec.rb
@@ -11,37 +11,37 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should exist }
   it { should be_owned_by 'haproxy' }
   it { should be_grouped_into 'haproxy' }
-  its('content') { should_not match(/daemon/) }
+  its('content') { should_not match(/^  daemon$/) }
   # Defaults
-  its('content') { should match(/timeout client 50s/) }
-  its('content') { should match(/timeout server 50s/) }
-  its('content') { should match(/timeout connect 5s/) }
-  its('content') { should match(/stick-table type ip size 200k expire 10m store gpc0/) }
-  its('content') { should match(%r{acl kml_request path_reg -i /kml}) }
-  its('content') { should match(%r{acl bbox_request path_reg -i /bbox}) }
-  its('content') { should match(/acl gina_host hdr\(host\) -i foo.bar.com/) }
-  its('content') { should match(/acl rrhost_host hdr\(host\) -i dave.foo.bar.com foo.foo.com/) }
-  its('content') { should match(/tcp-request connection track-sc1 src if !source_is_abuser/) }
+  its('content') { should match(/^  timeout client 50s$/) }
+  its('content') { should match(/^  timeout server 50s$/) }
+  its('content') { should match(/^  timeout connect 5s$/) }
+  its('content') { should match(/^  stick-table type ip size 200k expire 10m store gpc0$/) }
+  its('content') { should match(%r{^  acl kml_request path_reg -i /kml/$}) }
+  its('content') { should match(%r{^  acl bbox_request path_reg -i /bbox/$}) }
+  its('content') { should match(/^  acl gina_host hdr\(host\) -i foo.bar.com$/) }
+  its('content') { should match(/^  acl rrhost_host hdr\(host\) -i dave.foo.bar.com foo.foo.com$/) }
+  its('content') { should match(/^  tcp-request connection track-sc1 src if !source_is_abuser$/) }
   # Tiles Public
-  its('content') { should match(/backend tiles_public/) }
-  its('content') { should match(/conn_rate_abuse sc2_conn_rate gt 3000/) }
-  its('content') { should match(/data_rate_abuse sc2_bytes_out_rate gt 20000000/) }
-  its('content') { should match(/reject if conn_rate_abuse mark_as_abuser/) }
-  its('content') { should match(/tile0 10.0.0.10:80 check weight 1 maxconn 100/) }
-  its('content') { should match(/tile1/) }
+  its('content') { should match(/^backend tiles_public$/) }
+  its('content') { should match(/^  acl conn_rate_abuse sc2_conn_rate gt 3000$/) }
+  its('content') { should match(/^  acl data_rate_abuse sc2_bytes_out_rate gt 20000000$/) }
+  its('content') { should match(/^  tcp-request content reject if conn_rate_abuse mark_as_abuser$/) }
+  its('content') { should match(/^  server tile0 10.0.0.10:80 check weight 1 maxconn 100$/) }
+  its('content') { should match(/^  server tile1 10.0.0.10:80 check weight 1 maxconn 100$/) }
 
-  its('content') { should match(/backend abuser/) }
-  its('content') { should match(%r{errorfile 403 /etc/haproxy/errors/403.http}) }
+  its('content') { should match(/^backend abuser$/) }
+  its('content') { should match(%r{^  errorfile 403 /etc/haproxy/errors/403.http$}) }
 
-  its('content') { should match(/listen admin/) }
-  its('content') { should match(/bind 0.0.0.0:1337/) }
-  its('content') { should match(/mode http/) }
-  its('content') { should match(/acl network_allowed src 127.0.0.1/) }
-  its('content') { should match(/acl restricted_page path_beg /) }
-  its('content') { should match(/block if restricted_page !network_allowed/) }
-  its('content') { should match(%r{stats uri /}) }
-  its('content') { should match(/stats realm Haproxy-Statistics/) }
-  its('content') { should match(/stats auth user:pwd/) }
+  its('content') { should match(/^listen admin$/) }
+  its('content') { should match(/^  bind 0.0.0.0:1337$/) }
+  its('content') { should match(/^  mode http$/) }
+  its('content') { should match(/^  acl network_allowed src 127.0.0.1$/) }
+  its('content') { should match(%r{^  acl restricted_page path_beg /$}) }
+  its('content') { should match(/^  block if restricted_page !network_allowed$/) }
+  its('content') { should match(%r{^  stats uri /haproxy-status$}) }
+  its('content') { should match(/^  stats realm Haproxy-Statistics$/) }
+  its('content') { should match(/^  stats auth user:pwd$/) }
 end
 
 describe service('haproxy') do

--- a/test/integration/config_array/example_spec.rb
+++ b/test/integration/config_array/example_spec.rb
@@ -13,24 +13,24 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should exist }
   it { should be_owned_by 'haproxy' }
   it { should be_grouped_into 'haproxy' }
-  its('content') { should match(/daemon/) }
-  its('content') { should match(/timeout connect 5000ms/) }
-  its('content') { should match(/maxconn 256/) }
-  its('content') { should match(%r{stats socket /var/lib/haproxy/stats level admin}) }
-  its('content') { should match(%r{stats uri /haproxy-status}) }
-  its('content') { should match(/frontend http-in/) }
-  its('content') { should include('redirect prefix http://www.bar.com code 301 if { hdr(host) -i foo.com }') }
-  its('content') { should include('redirect prefix http://www.bar.com code 301 if { hdr(host) -i www.foo.com }') }
-  its('content') { should match(/frontend multiport/) }
-  its('content') { should match(/bind \*:80/) }
-  its('content') { should match(/bind \*:8080/) }
-  its('content') { should match(/bind 0.0.0.0:8081/) }
-  its('content') { should match(/bind 0.0.0.0:8180/) }
-  its('content') { should match(/^backend servers/) }
-  its('content') { should match(/default_backend servers/) }
-  its('content') { should match(/server server1 127.0.0.1:8000 maxconn 32/) }
-  its('content') { should match(/frontend tcp-in\n  mode tcp/) }
-  its('content') { should match(/backend tcp-servers\n  mode tcp/) }
+  its('content') { should match(/^  daemon$/) }
+  its('content') { should match(/^  timeout connect 5000ms$/) }
+  its('content') { should match(/^  maxconn 256$/) }
+  its('content') { should match(%r{^  stats socket /var/lib/haproxy/stats level admin$}) }
+  its('content') { should match(%r{^  stats uri /haproxy-status$}) }
+  its('content') { should match(/^frontend http-in$/) }
+  its('content') { should match(%r{^  redirect prefix http://www\.bar\.com code 301 if \{ hdr\(host\) -i foo\.com \}$}) }
+  its('content') { should match(%r{^  redirect prefix http://www\.bar\.com code 301 if \{ hdr\(host\) -i www\.foo\.com \}$}) }
+  its('content') { should match(/^frontend multiport$/) }
+  its('content') { should match(/^  bind \*:80$/) }
+  its('content') { should match(/^  bind \*:8080$/) }
+  its('content') { should match(/^  bind 0.0.0.0:8081$/) }
+  its('content') { should match(/^  bind 0.0.0.0:8180$/) }
+  its('content') { should match(/^backend servers$/) }
+  its('content') { should match(/^  default_backend servers$/) }
+  its('content') { should match(/^  server server1 127.0.0.1:8000 maxconn 32$/) }
+  its('content') { should match(/^frontend tcp-in\n  mode tcp$/) }
+  its('content') { should match(/^backend tcp-servers\n  mode tcp$/) }
 end
 
 describe service('haproxy') do

--- a/test/integration/config_backend_search/example_spec.rb
+++ b/test/integration/config_backend_search/example_spec.rb
@@ -13,13 +13,13 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should exist }
   it { should be_owned_by 'haproxy' }
   it { should be_grouped_into 'haproxy' }
-  its('content') { should match(/daemon/) }
-  its('content') { should match(/timeout connect 5000ms/) }
-  its('content') { should match(/frontend http-in/) }
-  its('content') { should match(/bind \*:80/) }
-  its('content') { should match(/backend servers/) }
-  its('content') { should match(/server be-1 10.0.0.75:8000 maxconn 32/) }
-  its('content') { should match(/server be-2 10.0.0.76:8000 maxconn 32/) }
+  its('content') { should match(/^  daemon$/) }
+  its('content') { should match(/^  timeout connect 5000ms$/) }
+  its('content') { should match(/^frontend http-in$/) }
+  its('content') { should match(/^  bind \*:80$/) }
+  its('content') { should match(/^backend servers$/) }
+  its('content') { should match(/^  server be-1 10.0.0.75:8000 maxconn 32$/) }
+  its('content') { should match(/^  server be-2 10.0.0.76:8000 maxconn 32$/) }
 end
 
 describe service('haproxy') do

--- a/test/integration/config_custom_template/example_spec.rb
+++ b/test/integration/config_custom_template/example_spec.rb
@@ -9,13 +9,13 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should be_owned_by 'haproxy' }
   it { should be_grouped_into 'haproxy' }
 
-  its('content') { should match(/^global/) }
+  its('content') { should match(/^global$/) }
   its('content') { should_not match(/^peers/) }
   its('content') { should_not match(/^mailers/) }
   its('content') { should_not match(/^listen/) }
   its('content') { should_not match(/^frontend/) }
   its('content') { should_not match(/^backend/) }
-  its('content') { should_not match(/bind/) }
+  its('content') { should_not match(/^  bind/) }
 end
 
 describe service('haproxy') do

--- a/test/integration/config_resolver/example_spec.rb
+++ b/test/integration/config_resolver/example_spec.rb
@@ -10,7 +10,7 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should be_grouped_into 'haproxy' }
 
   its('content') { should match(/^resolvers dns$/) }
-  its('content') { should match(/^\s\snameserver google 8.8.8.8:53$/) }
-  its('content') { should match(/^\s\sresolve_retries 30$/) }
-  its('content') { should match(/^\s\stimeout retry 1s$/) }
+  its('content') { should match(/^  nameserver google 8.8.8.8:53$/) }
+  its('content') { should match(/^  resolve_retries 30$/) }
+  its('content') { should match(/^  timeout retry 1s$/) }
 end

--- a/test/integration/config_ssl_redirect/example_spec.rb
+++ b/test/integration/config_ssl_redirect/example_spec.rb
@@ -13,18 +13,18 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should exist }
   it { should be_owned_by 'haproxy' }
   it { should be_grouped_into 'haproxy' }
-  its('content') { should match(/daemon/) }
-  its('content') { should match(/timeout connect 5000ms/) }
-  its('content') { should match(/maxconn 256/) }
-  its('content') { should match(%r{stats socket /var/lib/haproxy/stats level admin}) }
-  its('content') { should match(%r{stats uri /haproxy-status}) }
-  its('content') { should match(/frontend http-in/) }
-  its('content') { should match(/bind \*:80/) }
-  its('content') { should match(/redirect scheme https code 301 if !{ ssl_fc }/) }
-  its('content') { should match(/frontend https/) }
-  its('content') { should match(%r{bind \*:443 ssl crt /etc/ssl/private/example.com.pem}) }
-  its('content') { should match(/backend servers/) }
-  its('content') { should match(/server server1 127.0.0.1:8000 maxconn 32/) }
+  its('content') { should match(/^  daemon$/) }
+  its('content') { should match(/^  timeout connect 5000ms$/) }
+  its('content') { should match(/^  maxconn 256$/) }
+  its('content') { should match(%r{^  stats socket /var/lib/haproxy/stats level admin$}) }
+  its('content') { should match(%r{^  stats uri /haproxy-status$}) }
+  its('content') { should match(/^frontend http-in$/) }
+  its('content') { should match(/^  bind \*:80$/) }
+  its('content') { should match(/^  redirect scheme https code 301 if !{ ssl_fc }$/) }
+  its('content') { should match(/^frontend https$/) }
+  its('content') { should match(%r{^  bind \*:443 ssl crt /etc/ssl/private/example.com.pem$}) }
+  its('content') { should match(/^backend servers$/) }
+  its('content') { should match(/^  server server1 127.0.0.1:8000 maxconn 32$/) }
 end
 
 describe service('haproxy') do


### PR DESCRIPTION
### Description

All the integration test matches are updated to include checking for correct indentation from start of the line and spacing (or lack there of ) at the end of the lines.

I used the literal space character in lieu of the `\s` whitespace character as whitespace includes line breaks, which we specifically do not want in many cases.

### Issues Resolved

closes: https://github.com/sous-chefs/haproxy/issues/228

### Contribution Check List

- [X] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable