### PR TITLE
Add example to readme for subscribes multiple resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,9 +424,15 @@ haproxy_service 'haproxy'
 ```
 ```ruby
 haproxy_service 'haproxy' do
-  subscribes :reload, 'template[/etc/haproxy/haproxy.cfg]', :immediately
+  subscribes :reload, 'template[/etc/haproxy/haproxy.cfg]', :delayed
 end
 ```
+```ruby
+haproxy_service 'haproxy' do
+  subscribes :reload, ['template[/etc/haproxy/haproxy.cfg]', 'file[/etc/haproxy/ssl/haproxy.pem]'], :delayed
+end
+```
+
 ### haproxy_use_backend
 
 Switch to a specific backend if/unless an ACL-based condition is matched.


### PR DESCRIPTION
### Description

Documentation - adds an example of multiple `subscribes` in the `haproxy_service` resource to allow reloading haproxy when multiple files change, like certs and config.

### Issues Resolved

Fixes: #274 

### Contribution Check List

- [n/a] All tests pass.
- [n/a] New functionality includes testing.
- [n/a] New functionality has been documented in the README if applicable