### PR TITLE
Set haproxy rules in correct order in haproxy.cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 ## [unreleased]
 
+- Place haproxy rules in the approprite order per haproxy codebase 
 - Test for appropriate spacing from start of line and end of line
 
 ## [v6.2.6](2018-11-05)

--- a/spec/unit/recipes/frontend_backend_spec.rb
+++ b/spec/unit/recipes/frontend_backend_spec.rb
@@ -22,7 +22,7 @@ describe 'haproxy_' do
           'redirect' => 'redirect value',
           'tcp-request session' => 'session value',
           'tcp-request connection' => 'connection value'
-          )
+        )
       end
 
       haproxy_backend 'admin' do
@@ -34,7 +34,7 @@ describe 'haproxy_' do
           'reqadd' => 'reqadd backend',
           'redirect' => 'redirect backend',
           'reqdeny' => 'reqdeny backend'
-          )
+        )
       end
     end
 
@@ -55,13 +55,12 @@ describe 'haproxy_' do
 
       is_expected.not_to render_file('/etc/haproxy/haproxy.cfg').with_content(%r{use_backend admin0 if path_beg /admin0.*http-request add-header Test Value}m)
 
-      is_expected.to render_file('/etc/haproxy/haproxy.cfg').with_content(%r{\
-^  tcp-request content content backend$\n\
+      is_expected.to render_file('/etc/haproxy/haproxy.cfg').with_content(/^  tcp-request content content backend$\n\
 ^  block block backend$\n\
 ^  http-request add-header Backend Value$\n\
 ^  reqdeny reqdeny backend$\n\
 ^  reqadd reqadd backend$\n\
-^  redirect redirect backend$}m)
+^  redirect redirect backend$/m)
     end
   end
 end

--- a/spec/unit/recipes/frontend_backend_spec.rb
+++ b/spec/unit/recipes/frontend_backend_spec.rb
@@ -12,18 +12,56 @@ describe 'haproxy_' do
         bind '0.0.0.0:1337'
         mode 'http'
         use_backend ['admin0 if path_beg /admin0']
-        extra_options('http-request' => 'add-header Test Value')
+        extra_options(
+          'http-request' => 'add-header Test Value',
+          'tcp-request content' => 'content value',
+          'monitor fail' => 'monitor value',
+          'block' => 'block value',
+          'reqdeny' => 'reqdeny value',
+          'reqadd' => 'reqadd value',
+          'redirect' => 'redirect value',
+          'tcp-request session' => 'session value',
+          'tcp-request connection' => 'connection value'
+          )
       end
 
       haproxy_backend 'admin' do
         server ['admin0 10.0.0.10:80 check weight 1 maxconn 100']
+        tcp_request ['content content backend']
+        extra_options(
+          'http-request' => 'add-header Backend Value',
+          'block' => 'block backend',
+          'reqadd' => 'reqadd backend',
+          'redirect' => 'redirect backend',
+          'reqdeny' => 'reqdeny backend'
+          )
       end
     end
 
     it('should render content with http-request rule before use_backend') do
       is_expected.to render_file('/etc/haproxy/haproxy.cfg').with_content(/frontend admin/)
-      is_expected.to render_file('/etc/haproxy/haproxy.cfg').with_content(%r{http-request add-header Test Value.*use_backend admin0 if path_beg /admin0}m)
+
+      is_expected.to render_file('/etc/haproxy/haproxy.cfg').with_content(%r{\
+^  tcp-request connection connection value$\n\
+^  tcp-request session session value$\n\
+^  tcp-request content content value$\n\
+^  monitor fail monitor value$\n\
+^  block block value$\n\
+^  http-request add-header Test Value$\n\
+^  reqdeny reqdeny value$\n\
+^  reqadd reqadd value$\n\
+^  redirect redirect value$\n\
+^  use_backend admin0 if path_beg /admin0}m)
+
       is_expected.not_to render_file('/etc/haproxy/haproxy.cfg').with_content(%r{use_backend admin0 if path_beg /admin0.*http-request add-header Test Value}m)
+
+      is_expected.to render_file('/etc/haproxy/haproxy.cfg').with_content(%r{\
+^  tcp-request content content backend$\n\
+^  block block backend$\n\
+^  http-request add-header Backend Value$\n\
+^  reqdeny reqdeny backend$\n\
+^  reqadd reqadd backend$\n\
+^  redirect redirect backend$}m)
     end
   end
 end

--- a/spec/unit/recipes/listen_spec.rb
+++ b/spec/unit/recipes/listen_spec.rb
@@ -51,13 +51,35 @@ describe 'haproxy_listen' do
         bind '0.0.0.0:1337'
         mode 'http'
         use_backend ['admin0 if path_beg /admin0']
-        extra_options('http-request' => 'add-header Test Value')
+        http_request 'add-header Test Value'
+        extra_options(
+          'tcp-request content' => 'content value',
+          'monitor fail' => 'monitor value',
+          'block' => 'block value',
+          'reqdeny' => 'reqdeny value',
+          'reqadd' => 'reqadd value',
+          'redirect' => 'redirect value',
+          'tcp-request session' => 'session value',
+          'tcp-request connection' => 'connection value'
+        )
       end
     end
 
     it('should render content with http-request rule before use_backend') do
       is_expected.to render_file('/etc/haproxy/haproxy.cfg').with_content(/listen use_backend/)
-      is_expected.to render_file('/etc/haproxy/haproxy.cfg').with_content(%r{http-request add-header Test Value.*use_backend admin0 if path_beg /admin0}m)
+
+      is_expected.to render_file('/etc/haproxy/haproxy.cfg').with_content(%r{\
+^  tcp-request connection connection value$\n\
+^  tcp-request session session value$\n\
+^  tcp-request content content value$\n\
+^  monitor fail monitor value$\n\
+^  block block value$\n\
+^  http-request add-header Test Value$\n\
+^  reqdeny reqdeny value$\n\
+^  reqadd reqadd value$\n\
+^  redirect redirect value$\n\
+^  use_backend admin0 if path_beg /admin0}m)
+
       is_expected.not_to render_file('/etc/haproxy/haproxy.cfg').with_content(%r{use_backend admin0 if path_beg /admin0.*http-request add-header Test Value}m)
     end
   end

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -151,8 +151,10 @@ frontend <%= frontend %>
 <% end -%>
 <% end -%>
 <% unless f['extra_options'].nil? %>
+<% ['tcp-request connection','tcp-request session','tcp-request content','monitor fail','block','http-request','reqxxx','reqadd','redirect'].each do | extra_option | %>
+<% if extra_option == 'reqxxx' %>
 <% f['extra_options'].each do | key, value | %>
-<% if key == 'http-request' %>
+<% if /^req(?!add)(.*)/.match?(key) %>
 <% if value.is_a?(Array) %>
 <% value.each do | array_element | %>
   <%= key %> <%= array_element %>
@@ -160,6 +162,15 @@ frontend <%= frontend %>
 <% else %>
   <%= key %> <%= value %>
 <% end -%>
+<% end -%>
+<% end -%>
+<% elsif !f['extra_options'][extra_option].nil? %>
+<% if f['extra_options'][extra_option].is_a?(Array) %>
+<% f['extra_options'][extra_option].each do | array_element | %>
+  <%= extra_option %> <%= array_element %>
+<% end -%>
+<% else %>
+  <%= extra_option %> <%= f['extra_options'][extra_option] %>
 <% end -%>
 <% end -%>
 <% end -%>
@@ -177,13 +188,14 @@ frontend <%= frontend %>
 <% end -%>
 <% unless f['extra_options'].nil? %>
 <% f['extra_options'].each do | key, value | %>
-<% unless key == 'http-request' %>
+<% unless (['tcp-request connection','tcp-request session','tcp-request content','monitor fail','block','http-request','reqadd','redirect'].include? key) || /^req.*/.match?(key) %>
 <% if value.is_a?(Array) %>
 <% value.each do | array_element | %>
   <%= key %> <%= array_element %>
 <% end -%>
 <% else %>
   <%= key %> <%= value %>
+<% end -%>
 <% end -%>
 <% end -%>
 <% end -%>
@@ -225,13 +237,27 @@ backend <%= key %>
 <% end -%>
 <% end -%>
 <% unless backend['extra_options'].nil? %>
-<% backend['extra_options'].each do | key, value |%>
+<% ['block','http-request','reqxxx','reqadd','redirect'].each do | extra_option | %>
+<% if extra_option == 'reqxxx' %>
+<% backend['extra_options'].each do | key, value | %>
+<% if /^req(?!add)(.*)/.match?(key) %>
 <% if value.is_a?(Array) %>
 <% value.each do | array_element | %>
   <%= key %> <%= array_element %>
 <% end -%>
 <% else %>
   <%= key %> <%= value %>
+<% end -%>
+<% end -%>
+<% end -%>
+<% elsif !backend['extra_options'][extra_option].nil? %>
+<% if backend['extra_options'][extra_option].is_a?(Array) %>
+<% backend['extra_options'][extra_option].each do | array_element | %>
+  <%= extra_option %> <%= array_element %>
+<% end -%>
+<% else %>
+  <%= extra_option %> <%= backend['extra_options'][extra_option] %>
+<% end -%>
 <% end -%>
 <% end -%>
 <% end -%>
@@ -254,6 +280,19 @@ listen <%= key %>
 <% listen['stats']&.each do |option, value| -%>
   stats <%= option %> <%= value %>
 <% end -%>
+<% unless listen['extra_options'].nil? %>
+<% ['tcp-request connection','tcp-request session','tcp-request content','monitor fail','block'].each do | extra_option |  %>
+<% unless listen['extra_options'][extra_option].nil? %>
+<% if listen['extra_options'][extra_option].is_a?(Array) %>
+<% listen['extra_options'][extra_option].each do | array_element | %>
+  <%= extra_option %> <%= array_element %>
+<% end -%>
+<% else %>
+  <%= extra_option %> <%= listen['extra_options'][extra_option] %>
+<% end -%>
+<% end -%>
+<% end -%>
+<% end -%>
 <% if listen['http_request'] -%>
   http-request <%= listen['http_request'] %>
 <% end %>
@@ -269,14 +308,26 @@ listen <%= key %>
 <% end -%>
 <% end -%>
 <% unless listen['extra_options'].nil? %>
+<% ['reqxxx','reqadd','redirect'].each do | extra_option | %>
+<% if extra_option == 'reqxxx' %>
 <% listen['extra_options'].each do | key, value | %>
-<% if key == 'http-request' %>
+<% if /^req(?!add)(.*)/.match?(key) %>
 <% if value.is_a?(Array) %>
 <% value.each do | array_element | %>
   <%= key %> <%= array_element %>
 <% end -%>
 <% else %>
   <%= key %> <%= value %>
+<% end -%>
+<% end -%>
+<% end -%>
+<% elsif !listen['extra_options'][extra_option].nil? %>
+<% if listen['extra_options'][extra_option].is_a?(Array) %>
+<% listen['extra_options'][extra_option].each do | array_element | %>
+  <%= extra_option %> <%= array_element %>
+<% end -%>
+<% else %>
+  <%= extra_option %> <%= listen['extra_options'][extra_option] %>
 <% end -%>
 <% end -%>
 <% end -%>
@@ -288,7 +339,7 @@ listen <%= key %>
 <% end -%>
 <% unless listen['extra_options'].nil? %>
 <% listen['extra_options'].each do | key, value | %>
-<% unless key == 'http-request' %>
+<% unless (['tcp-request connection','tcp-request session','tcp-request content','monitor fail','block','http-request','reqadd','redirect'].include? key) || /^req.*/.match?(key) %>
 <% if value.is_a?(Array) %>
 <% value.each do | array_element | %>
   <%= key %> <%= array_element %>


### PR DESCRIPTION
### Description
Checks for the specific frontend/listen/backend extra options that must be applied in appropriate ordering in the haproxy.cfg.

the haproxy.cfg validation check `haproxy -c -V -f /etc/haproxy/haproxy.cfg` will otherwise return errors complaining that a rule is placed after a rule, where it should be placed before.

This enhances #315

### Issues Resolved

Closes #319 

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable