### PR TITLE
Allow array to haproxy_listen's http_request param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 ## [unreleased]
 
 - Test for appropriate spacing from start of line and end of line
+- Allow passing an array to `haproxy_listen`'s `http_request` param
 
 ## [v6.2.6](2018-11-05)
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Introduced: v4.0.0
 - `bind` -  (is: [String, Hash])
 - `maxconn` -  (is: Integer)
 - `stats` -  (is: Hash)
-- `http_request` -  (is: String)
+- `http_request` -  (is: [Array, String])
 - `http_response` -  (is: String)
 - `default_backend` -  (is: String)
 - `use_backend` -  (is: Array)

--- a/resources/listen.rb
+++ b/resources/listen.rb
@@ -2,7 +2,7 @@ property :mode, String, equal_to: %w(http tcp)
 property :bind, [String, Hash], default: '0.0.0.0:80'
 property :maxconn, Integer
 property :stats, Hash
-property :http_request, String
+property :http_request, [Array, String]
 property :http_response, String
 property :default_backend, String
 property :use_backend, Array
@@ -38,8 +38,7 @@ action :create do
       variables['listen'][new_resource.name]['maxconn'] << new_resource.maxconn.to_s unless new_resource.maxconn.nil?
       variables['listen'][new_resource.name]['stats'] ||= {} unless new_resource.stats.nil?
       variables['listen'][new_resource.name]['stats'].merge!(new_resource.stats) unless new_resource.stats.nil?
-      variables['listen'][new_resource.name]['http_request'] ||= '' unless new_resource.http_request.nil?
-      variables['listen'][new_resource.name]['http_request'] << new_resource.http_request unless new_resource.http_request.nil?
+      variables['listen'][new_resource.name]['http_request'] = [new_resource.http_request].flatten unless new_resource.http_request.nil?
       variables['listen'][new_resource.name]['http_response'] ||= '' unless new_resource.http_response.nil?
       variables['listen'][new_resource.name]['http_response'] << new_resource.http_response unless new_resource.http_response.nil?
       variables['listen'][new_resource.name]['use_backend'] ||= [] unless new_resource.use_backend.nil?

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -255,7 +255,9 @@ listen <%= key %>
   stats <%= option %> <%= value %>
 <% end -%>
 <% if listen['http_request'] -%>
-  http-request <%= listen['http_request'] %>
+<% listen['http_request'].each do |http_request| %>
+  http-request <%= http_request %>
+<% end -%>
 <% end %>
 <% if listen['http_response'] -%>
   http-response <%= listen['http_response'] %>

--- a/test/fixtures/cookbooks/test/recipes/config_4.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_4.rb
@@ -11,7 +11,10 @@ haproxy_listen 'admin' do
   stats uri: '/',
         realm: 'Haproxy-Statistics',
         auth: 'user:pwd'
-  http_request 'add-header X-Proto http'
+  http_request [
+    'add-header X-Forwarded-Proto https if { ssl_fc }',
+    'add-header X-Proto http',
+  ]
   http_response 'set-header Expires %[date(3600),http_date]'
   default_backend 'servers'
   extra_options('bind-process' => 'odd')

--- a/test/integration/config_4/example_spec.rb
+++ b/test/integration/config_4/example_spec.rb
@@ -11,17 +11,20 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should exist }
   it { should be_owned_by 'haproxy' }
   it { should be_grouped_into 'haproxy' }
-
-  its('content') { should match(/^listen admin$/) }
-  its('content') { should match(/^  bind 0.0.0.0:1337$/) }
-  its('content') { should match(/^  mode http$/) }
-  its('content') { should match(%r{^  stats uri /haproxy-status$}) }
-  its('content') { should match(/^  stats realm Haproxy-Statistics$/) }
-  its('content') { should match(/^  stats auth user:pwd$/) }
-  its('content') { should match(/^  http-request add-header X-Proto http$/) }
-  its('content') { should match(/^  http-response set-header Expires \%\[date\(3600\),http_date\]$/) }
-  its('content') { should match(/^  default_backend servers$/) }
-  its('content') { should match(/^  bind-process odd$/) }
+  listen_config = [
+    'listen admin',
+    '  mode http',
+    '  bind 0.0.0.0:1337',
+    '  stats uri /',
+    '  stats realm Haproxy-Statistics',
+    '  stats auth user:pwd',
+    '  http-request add-header X-Forwarded-Proto https if { ssl_fc }',
+    '  http-request add-header X-Proto http',
+    '  http-response set-header Expires %\[date\(3600\),http_date\]',
+    '  default_backend servers',
+    '  bind-process odd',
+  ]
+  its('content') { should match /#{listen_config.join('\n')}/ }
 end
 
 describe service('haproxy') do


### PR DESCRIPTION
### Description

In an HAProxy `listen` block it's possible to define multiple `http-request` statements but the cookbook doesn't yet support it.

This PR adds support to pass an array to the `haproxy_listen`'s `http_request` param.

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable