### PR TITLE
Fix acl order in listen blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 - Test for appropriate spacing from start of line and end of line
 - Allow passing an array to `haproxy_listen`'s `http_request` param
+- Fix ordering for `haproxy_listen`: `acl` directives should be applied before `http-request`
 
 ## [v6.2.6](2018-11-05)
 

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -254,6 +254,11 @@ listen <%= key %>
 <% listen['stats']&.each do |option, value| -%>
   stats <%= option %> <%= value %>
 <% end -%>
+<% unless listen['acl'].nil? %>
+<% listen['acl'].flatten.uniq.each do | acl |%>
+  acl <%= acl %>
+<% end -%>
+<% end -%>
 <% if listen['http_request'] -%>
 <% listen['http_request'].each do |http_request| %>
   http-request <%= http_request %>
@@ -265,11 +270,6 @@ listen <%= key %>
 <% if listen['default_backend'] -%>
   default_backend <%= listen['default_backend'] %>
 <% end %>
-<% unless listen['acl'].nil? %>
-<% listen['acl'].flatten.uniq.each do | acl |%>
-  acl <%= acl %>
-<% end -%>
-<% end -%>
 <% unless listen['extra_options'].nil? %>
 <% listen['extra_options'].each do | key, value | %>
 <% if key == 'http-request' %>

--- a/test/integration/config_acl/example_spec.rb
+++ b/test/integration/config_acl/example_spec.rb
@@ -13,35 +13,71 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should be_grouped_into 'haproxy' }
   its('content') { should_not match(/^  daemon$/) }
   # Defaults
-  its('content') { should match(/^  timeout client 50s$/) }
-  its('content') { should match(/^  timeout server 50s$/) }
-  its('content') { should match(/^  timeout connect 5s$/) }
-  its('content') { should match(/^  stick-table type ip size 200k expire 10m store gpc0$/) }
-  its('content') { should match(%r{^  acl kml_request path_reg -i /kml/$}) }
-  its('content') { should match(%r{^  acl bbox_request path_reg -i /bbox/$}) }
-  its('content') { should match(/^  acl gina_host hdr\(host\) -i foo.bar.com$/) }
-  its('content') { should match(/^  acl rrhost_host hdr\(host\) -i dave.foo.bar.com foo.foo.com$/) }
-  its('content') { should match(/^  tcp-request connection track-sc1 src if !source_is_abuser$/) }
-  # Tiles Public
-  its('content') { should match(/^backend tiles_public$/) }
-  its('content') { should match(/^  acl conn_rate_abuse sc2_conn_rate gt 3000$/) }
-  its('content') { should match(/^  acl data_rate_abuse sc2_bytes_out_rate gt 20000000$/) }
-  its('content') { should match(/^  tcp-request content reject if conn_rate_abuse mark_as_abuser$/) }
-  its('content') { should match(/^  server tile0 10.0.0.10:80 check weight 1 maxconn 100$/) }
-  its('content') { should match(/^  server tile1 10.0.0.10:80 check weight 1 maxconn 100$/) }
-
-  its('content') { should match(/^backend abuser$/) }
-  its('content') { should match(%r{^  errorfile 403 /etc/haproxy/errors/403.http$}) }
-
-  its('content') { should match(/^listen admin$/) }
-  its('content') { should match(/^  bind 0.0.0.0:1337$/) }
-  its('content') { should match(/^  mode http$/) }
-  its('content') { should match(/^  acl network_allowed src 127.0.0.1$/) }
-  its('content') { should match(%r{^  acl restricted_page path_beg /$}) }
-  its('content') { should match(/^  block if restricted_page !network_allowed$/) }
-  its('content') { should match(%r{^  stats uri /haproxy-status$}) }
-  its('content') { should match(/^  stats realm Haproxy-Statistics$/) }
-  its('content') { should match(/^  stats auth user:pwd$/) }
+  defaults = [
+    'defaults',
+    '  timeout connect 5s',
+    '  timeout client 50s',
+    '  timeout server 50s',
+    '  log global',
+    '  mode http',
+    '  balance roundrobin',
+    '  option httplog',
+    '  option dontlognull',
+    '  option redispatch',
+    '  option tcplog',
+    '  stats uri /haproxy-status',
+  ]
+  its('content') { should match(/#{defaults.join('\n')}/) }
+  # Frontend http
+  frontend_http = [
+    'frontend http',
+    '  default_backend rrhost',
+    '  bind 0.0.0.0:80',
+    '  maxconn 2000',
+    '  acl kml_request path_reg -i /kml/',
+    '  acl bbox_request path_reg -i /bbox/',
+    '  acl source_is_abuser src_get_gpc0\(http\) gt 0',
+    '  acl gina_host hdr\(host\) -i foo.bar.com',
+    '  acl rrhost_host hdr\(host\) -i dave.foo.bar.com foo.foo.com',
+    '  acl tile_host hdr\(host\) -i dough.foo.bar.com',
+    '  use_backend abuser if source_is_abuser',
+    '  use_backend gina if gina_host',
+    '  use_backend rrhost if rrhost_host',
+    '  use_backend tiles_public if tile_host',
+    '  option httplog',
+    '  option dontlognull',
+    '  option forwardfor',
+    '  stick-table type ip size 200k expire 10m store gpc0',
+    '  tcp-request connection track-sc1 src if !source_is_abuser',
+  ]
+  its('content') { should match(/#{frontend_http.join('\n')}/) }
+  # Backend tiles_public
+  tiles_public = [
+    'backend tiles_public',
+    '  server tile0 10.0.0.10:80 check weight 1 maxconn 100',
+    '  server tile1 10.0.0.10:80 check weight 1 maxconn 100',
+    '  acl conn_rate_abuse sc2_conn_rate gt 3000',
+    '  acl data_rate_abuse sc2_bytes_out_rate gt 20000000',
+    '  acl mark_as_abuser sc1_inc_gpc0 gt 0',
+    '  tcp-request content track-sc2 src',
+    '  tcp-request content reject if conn_rate_abuse mark_as_abuser',
+    '  stick-table type ip size 200k expire 2m store conn_rate\(60s\),bytes_out_rate\(60s\)',
+    '  http-request set-header X-Public-User yes',
+  ]
+  its('content') { should match(/#{tiles_public.join('\n')}/) }
+  # Listen admin
+  listen_admin = [
+    'listen admin',
+    '  mode http',
+    '  bind 0.0.0.0:1337',
+    '  stats uri /',
+    '  stats realm Haproxy-Statistics',
+    '  stats auth user:pwd',
+    '  acl network_allowed src 127.0.0.1',
+    '  acl restricted_page path_beg /',
+    '  block if restricted_page !network_allowed',
+  ]
+  its('content') { should match(/#{listen_admin.join('\n')}/) }
 end
 
 describe service('haproxy') do


### PR DESCRIPTION
### Description

The ordering is incorrect; `acl` directives should be placed above `http-request` or `http-request` cannot refer to declared `acl`s.

This is fixed by amending the template.

I also amended the tests as they didn't test correct order, they tested single line strings existed anywhere in the config file.

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable