### PR TITLE
Add hash type param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 - Test for appropriate spacing from start of line and end of line
 - Allow passing an array to `haproxy_listen`'s `http_request` param
 - Fix ordering for `haproxy_listen`: `acl` directives should be applied before `http-request`
+- Add a hash_type param to haproxy_backend, haproxy_listen, and haproxy_config_defaults resources
 
 ## [v6.2.6](2018-11-05)
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Introduced: v4.0.0
 - `acl` -  (is: Array)
 - `option` -  (is: Array)
 - `extra_options` -  (is: Hash)
+- 'hash_type' -  (is: String, equal_to: ['consistent', 'map-based'])
 - `config_dir` -  (is: String)
 - `config_file` -  (is: String)
 
@@ -142,6 +143,7 @@ Introduced: v4.0.0
 - `log` -  (is: String)
 - `mode` -  (is: String)
 - `balance` -  (is: )
+- 'hash_type' -  (is: String, equal_to: ['consistent', 'map-based'])
 - `option` -  (is: Array)
 - `stats` -  (is: Hash)
 - `maxconn` -  (is: Integer)
@@ -343,6 +345,7 @@ Introduced: v4.0.0
 - `acl` -  (is: Array)
 - `extra_options` -  (is: Hash)
 - `server` -  (is: Array)
+- 'hash_type' -  (is: String, equal_to: ['consistent', 'map-based'])
 - `config_dir` -  (is: String)
 - `config_file` -  (is: String)
 

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -6,6 +6,7 @@ property :option, Array
 property :extra_options, Hash
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
+property :hash_type, String, equal_to: %w(consistent map-based)
 
 action :create do
   # As we're using the accumulator pattern we need to shove everything
@@ -27,6 +28,7 @@ action :create do
       variables['backend'][new_resource.name]['acl'] << new_resource.acl unless new_resource.acl.nil?
       variables['backend'][new_resource.name]['option'] ||= [] unless new_resource.option.nil?
       variables['backend'][new_resource.name]['option'] << new_resource.option unless new_resource.option.nil?
+      variables['backend'][new_resource.name]['hash_type'] = new_resource.hash_type unless new_resource.hash_type.nil?
       variables['backend'][new_resource.name]['extra_options'] ||= {} unless new_resource.extra_options.nil?
       variables['backend'][new_resource.name]['extra_options'] = new_resource.extra_options unless new_resource.extra_options.nil?
 

--- a/resources/config_defaults.rb
+++ b/resources/config_defaults.rb
@@ -9,6 +9,7 @@ property :extra_options, Hash
 property :haproxy_retries, Integer
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
+property :hash_type, [String, nil], default: nil, equal_to: ['consistent', 'map-based', nil]
 
 action :create do
   # As we're using the accumulator pattern we need to shove everything
@@ -35,6 +36,7 @@ action :create do
       variables['defaults']['maxconn'] << new_resource.maxconn.to_s unless new_resource.maxconn.nil?
       variables['defaults']['retries'] ||= '' unless new_resource.haproxy_retries.nil?
       variables['defaults']['retries'] << new_resource.haproxy_retries.to_s unless new_resource.haproxy_retries.nil?
+      variables['defaults']['hash_type'] = new_resource.hash_type unless new_resource.hash_type.nil?
       variables['defaults']['extra_options'] ||= {} unless new_resource.extra_options.nil?
       variables['defaults']['extra_options'] = new_resource.extra_options unless new_resource.extra_options.nil?
 

--- a/resources/listen.rb
+++ b/resources/listen.rb
@@ -11,6 +11,7 @@ property :extra_options, Hash
 property :server, Array
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
+property :hash_type, String, equal_to: %w(consistent map-based)
 
 action :create do
   # As we're using the accumulator pattern we need to shove everything
@@ -49,6 +50,7 @@ action :create do
       variables['listen'][new_resource.name]['default_backend'] << new_resource.default_backend unless new_resource.default_backend.nil?
       variables['listen'][new_resource.name]['server'] ||= [] unless new_resource.server.nil?
       variables['listen'][new_resource.name]['server'] << new_resource.server unless new_resource.server.nil?
+      variables['listen'][new_resource.name]['hash_type'] = new_resource.hash_type unless new_resource.hash_type.nil?
       variables['listen'][new_resource.name]['extra_options'] ||= {} unless new_resource.extra_options.nil?
       variables['listen'][new_resource.name]['extra_options'] = new_resource.extra_options unless new_resource.extra_options.nil?
 

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -87,6 +87,9 @@ defaults
 <% unless @defaults['balance'].empty? -%>
   balance <%= @defaults['balance'] %>
 <% end -%>
+<% if @defaults['hash_type'] -%>
+  hash-type <%= @defaults['hash_type'] %>
+<% end -%>
 <% @defaults['option'].each do | option | -%>
   option <%= option %>
 <% end -%>
@@ -224,6 +227,9 @@ backend <%= key %>
 <% end -%>
 <% end -%>
 <% end -%>
+<% if backend['hash_type'] -%>
+  hash-type <%= backend['hash_type'] %>
+<% end -%>
 <% unless backend['extra_options'].nil? %>
 <% backend['extra_options'].each do | key, value |%>
 <% if value.is_a?(Array) %>
@@ -305,6 +311,9 @@ listen <%= key %>
 <% s.each  do |server|%>
   server <%= server %>
 <% end -%>
+<% end -%>
+<% if listen['hash_type'] -%>
+  hash-type <%= listen['hash_type'] %>
 <% end -%>
 <% end # listen loop -%>
 <% end # listen -%>

--- a/test/fixtures/cookbooks/test/recipes/config_4.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_4.rb
@@ -3,7 +3,9 @@ haproxy_install 'package'
 
 haproxy_config_global ''
 
-haproxy_config_defaults ''
+haproxy_config_defaults '' do
+  hash_type 'consistent'
+end
 
 haproxy_listen 'admin' do
   bind '0.0.0.0:1337'
@@ -18,10 +20,12 @@ haproxy_listen 'admin' do
   http_response 'set-header Expires %[date(3600),http_date]'
   default_backend 'servers'
   extra_options('bind-process' => 'odd')
+  hash_type 'consistent'
 end
 
 haproxy_backend 'servers' do
   server ['disabled-server 127.0.0.1:1 disabled']
+  hash_type 'consistent'
 end
 
 haproxy_service 'haproxy'

--- a/test/integration/config_4/example_spec.rb
+++ b/test/integration/config_4/example_spec.rb
@@ -11,7 +11,40 @@ describe file('/etc/haproxy/haproxy.cfg') do
   it { should exist }
   it { should be_owned_by 'haproxy' }
   it { should be_grouped_into 'haproxy' }
-  listen_config = [
+  cfg_content = [
+    'global',
+    '  user haproxy',
+    '  group haproxy',
+    '  log /dev/log syslog info',
+    '  log-tag haproxy',
+    '  daemon',
+    '  quiet',
+    '  stats socket /var/run/haproxy.sock user haproxy group haproxy',
+    '  stats timeout 2m',
+    '  maxconn 4096',
+    '  pidfile /var/run/haproxy.pid',
+    '',
+    '',
+    'defaults',
+    '  timeout client 10s',
+    '  timeout server 10s',
+    '  timeout connect 10s',
+    '  log global',
+    '  mode http',
+    '  balance roundrobin',
+    '  hash-type consistent',
+    '  option httplog',
+    '  option dontlognull',
+    '  option redispatch',
+    '  option tcplog',
+    '  stats uri /haproxy-status',
+    '',
+    '',
+    'backend servers',
+    '  server disabled-server 127.0.0.1:1 disabled',
+    '  hash-type consistent',
+    '',
+    '',
     'listen admin',
     '  mode http',
     '  bind 0.0.0.0:1337',
@@ -23,8 +56,9 @@ describe file('/etc/haproxy/haproxy.cfg') do
     '  http-response set-header Expires %\[date\(3600\),http_date\]',
     '  default_backend servers',
     '  bind-process odd',
+    '  hash-type consistent',
   ]
-  its('content') { should match /#{listen_config.join('\n')}/ }
+  its('content') { should match /#{cfg_content.join('\n')}/ }
 end
 
 describe service('haproxy') do


### PR DESCRIPTION
### Description

Add a `hash_type` param to `haproxy_backend`, `haproxy_listen`, and `haproxy_config_defaults` resources.

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable