### PR TITLE
Add sensitive param to haproxy_install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 - Fix ordering for `haproxy_listen`: `acl` directives should be applied before `http-request`
 - Add `hash_type` param to `haproxy_backend`, `haproxy_listen`, and `haproxy_config_defaults` resources
 - Add `reqirep` and `reqrep` params to `haproxy_backend`, `haproxy_listen`, and `haproxy_listen` resources
+- Add `sensitive` param to `haproxy_install`; set to false to show diff output during Chef run
 
 ## [v6.2.6](2018-11-05)
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Introduced: v4.0.0
 - `haproxy_user` -  (is: String)
 - `haproxy_group` -  (is: String)
 - `install_only` -  (is: [true, false])
+- `sensitive` -  (is: [true, false], default: true)
 - `service_name` -  (is: String)
 - `use_systemd` -  (is: String)
 - `package_name` -  (is: String)

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -9,6 +9,7 @@ property :haproxy_user, String, default: 'haproxy'
 property :haproxy_group, String, default: 'haproxy'
 property :install_only, [true, false], default: false
 property :service_name, String, default: 'haproxy'
+property :sensitive, [true, false], default: true
 property :use_systemd, String, equal_to: %w(0 1), default: lazy { node['init_package'] == 'systemd' ? '1' : '0' }
 
 # Package
@@ -118,7 +119,7 @@ action :create do
       owner new_resource.haproxy_user
       group new_resource.haproxy_group
       mode new_resource.conf_file_mode
-      sensitive true
+      sensitive new_resource.sensitive
       source lazy { node.run_state['haproxy']['conf_template_source'][config_file] }
       cookbook lazy { node.run_state['haproxy']['conf_cookbook'][config_file] }
       variables()

--- a/test/fixtures/cookbooks/test/recipes/config_1.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_1.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-haproxy_install 'package'
+haproxy_install 'package' do
+  sensitive false
+end
 
 haproxy_config_global '' do
   chroot '/var/lib/haproxy'


### PR DESCRIPTION
### Description

Default behaviour is to suppress diff of haproxy config file which is fine if you have some sensitive data but if you don't then it's nice to see the diff.

This PR keeps this behaviour be default but adds a `sensitive` param to `haproxy_install` which can be set to `false` if desired.

Don't think this is testable but added it to one of the tests anyway to make sure it still converges.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable