### PR TITLE
Instead of passing USE_XXX=0 passing USE_XXX=

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures haproxy'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '6.2.7'
+version           '6.2.8'
 source_url        'https://github.com/sous-chefs/haproxy'
 issues_url        'https://github.com/sous-chefs/haproxy/issues'
 chef_version      '>= 13.0'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -45,6 +45,8 @@ action :create do
   node.run_state['haproxy']['conf_template_source'][new_resource.config_file] = new_resource.conf_template_source
   node.run_state['haproxy']['conf_cookbook'][new_resource.config_file] = new_resource.conf_cookbook
 
+  normalize_build_flag = ->(use_value) { use_value.to_s == '1' ? '1' : '' }
+
   case new_resource.install_type
   when 'package'
     package new_resource.package_name do
@@ -80,12 +82,12 @@ action :create do
     make_cmd = "make TARGET=#{new_resource.source_target_os}"
     make_cmd << " CPU=#{new_resource.source_target_cpu}" unless new_resource.source_target_cpu.nil?
     make_cmd << " ARCH=#{new_resource.source_target_arch}" unless new_resource.source_target_arch.nil?
-    make_cmd << " USE_LIBCRYPT=#{new_resource.use_libcrypt}"
-    make_cmd << " USE_PCRE=#{new_resource.use_pcre}"
-    make_cmd << " USE_OPENSSL=#{new_resource.use_openssl}"
-    make_cmd << " USE_ZLIB=#{new_resource.use_zlib}"
-    make_cmd << " USE_LINUX_TPROXY=#{new_resource.use_linux_tproxy}"
-    make_cmd << " USE_LINUX_SPLICE=#{new_resource.use_linux_splice}"
+    make_cmd << " USE_LIBCRYPT=#{normalize_build_flag[new_resource.use_libcrypt]}"
+    make_cmd << " USE_PCRE=#{normalize_build_flag[new_resource.use_pcre]}"
+    make_cmd << " USE_OPENSSL=#{normalize_build_flag[new_resource.use_openssl]}"
+    make_cmd << " USE_ZLIB=#{normalize_build_flag[new_resource.use_zlib]}"
+    make_cmd << " USE_LINUX_TPROXY=#{normalize_build_flag[new_resource.use_linux_tproxy]}"
+    make_cmd << " USE_LINUX_SPLICE=#{normalize_build_flag[new_resource.use_linux_splice]}"
     make_cmd << " USE_SYSTEMD=#{new_resource.use_systemd}" if new_resource.use_systemd == '1' && new_resource.source_version.to_f >= 1.8
     extra_cmd = ' EXTRA=haproxy-systemd-wrapper' if new_resource.source_version.to_f < 1.8
 


### PR DESCRIPTION
> **NOTE:** this fixes a build issue experienced when installing an older version of haproxy (version 1.5).

This PR attempts to fix build issue I experienced on Ubuntu 18.04 when building haproxy, due to it not finding appropriate dependencies to compile with SSL support enabled. 

I used `use_openssl '0'`, and saw that the command line changed to have `-DUSE_SSL=0`, but unfortunately this still seems to "enable" the build flag. Only by passing a blank string was I able to build haproxy without any problems.

### Description

Makes disabling various build-time features possible. Current implementation always enables them.

### Issues Resolved

No issue has been created (yet).
