### PR TITLE
clarify extra_options hash string => array option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 ## [unreleased]
 
 - Expand integration test coverage to all stable and LTS HAProxy versions
+- Documentation - clarify extra_options hash string => array option
 
 ## [v6.2.7](2019-01-10)
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ haproxy_listen 'disabled' do
 end
 ```
 
+The `extra_options` hash is of `String => String` or `String => Array`. When an `Array` value is provided. The values are looped over mapping the key to each value in the config.
+
+For example:
+
+```ruby
+haproxy_listen 'default' do
+  extra_options(
+    'http-request' => [ 'set-header X-Public-User yes', 'del-header X-Bad-Header' ]
+    )
+end
+```
+Becomes:
+```
+listen default
+  ...
+  http-request set-header X-Public-User yes
+  http-request del-header X-Bad-Header
+```
+
 ## Resources
 
 ### haproxy_acl


### PR DESCRIPTION
### Description

Clarify in the docs - due to ongoing confusion: https://github.com/sous-chefs/haproxy/issues/268

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable