### PR TITLE
Use direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use chefworkstation


### PR DESCRIPTION
# Description

If you have `direnv` installed & a function called chefworkstation like below, this will allow switching of Rubies from the system Ruby automatically. 

I'll probably blog about this on sous-chefs.org once we have a few people using it. 

Originally from @robbkidd's [blog post](http://www.thekidds.org/blog/2016/03/07/closer-to-environmental-bliss-with-direnv/)

## Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

## Code Snippet
<details>
  <summary>Click to view snippet</summary>
```bash
use_chefworkstation() {
	source /usr/local/opt/chruby/share/chruby/chruby.sh
  chruby 🍳
  layout_ruby

  log_status "Overriding default Ruby environment to use Chef Workstation"
  RUBY_ABI_VERSION=`ls /opt/chef-workstation/embedded/lib/ruby/gems`
  export GEM_ROOT="/opt/chef-workstation/embedded/lib/ruby/gems/$RUBY_ABI_VERSION"

	EXPANDED_HOME=`expand_path ~`
  export GEM_HOME="$EXPANDED_HOME/.chef-workstation/gem/ruby/$RUBY_ABI_VERSION"
  export GEM_PATH="$EXPANDED_HOME/.chef-workstation/gem/ruby/$RUBY_ABI_VERSION:/opt/chef-workstation/embedded/lib/ruby/gems/$RUBY_ABI_VERSION"

  log_status "Ensuring ChefDK and it's embedded tools are first in the PATH"

  PATH_add $EXPANDED_HOME/.chef-workstation/gem/ruby/$RUBY_ABI_VERSION/bin/
  PATH_add /opt/chef-workstation/embedded/bin
  PATH_add /opt/chef-workstation/bin
  PATH_add /Users/dmw/.chefdk/gem/ruby/2.5.0/bin

  log_status "Using 🍳 chef-workstation 🍳 Happy Cheffing"
}
```
</details>
