### PR TITLE
Use the orb major version 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ lint_and_unit: &lint_and_unit
 version: 2.1
 
 orbs:
-  kitchen: sous-chefs/kitchen@dev:first
+  kitchen: sous-chefs/kitchen@1
 
 workflows:
   kitchen:


### PR DESCRIPTION
### Description

CircleCI uses semantic versioning for orbs, [see here](https://circleci.com/docs/2.0/creating-orbs/#semantic-versioning-in-orbs)

So this will use `1.1.2` and any version until breaking changes are made with version `2.x.x`

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable