### PR TITLE
Fix Debian Tests

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -18,14 +18,14 @@ platforms:
       image: dokken/debian-8
       pid_one_command: /bin/systemd
       intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get update -y
 
   - name: debian-9
     driver:
       image: dokken/debian-9
       pid_one_command: /bin/systemd
       intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get update -y
 
   - name: centos-6
     driver:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 - Add `health` to allowed values for `mode` on `frontend`, `backend`, `listen`, `default`
 - Fix cookbook default value in `config_global`
 - Clean up unit and integration test content regular expressions
+- Fix failing Debian integration tests, missing `-y` on `apt-get update`
 
 ## [v6.4.0] (2019-03-20)
 


### PR DESCRIPTION
### Description

All the debian tests are failing to kick-off see [here](https://circleci.com/gh/sous-chefs/haproxy/3206?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) and [here](https://circleci.com/gh/sous-chefs/haproxy/3203?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) and more [here](https://circleci.com/gh/sous-chefs/haproxy/3202?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) and [here](https://circleci.com/gh/sous-chefs/haproxy/3205?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)
### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable