### PR TITLE
Fix name conflict with systemd_unit in service resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 ## Unreleased
 
 - Clean up unused templates and files
+- Fix name conflict with systemd_unit in service resource
 
 ## [v7.0.0] (2019-04-10)
 

--- a/documentation/haproxy_service.md
+++ b/documentation/haproxy_service.md
@@ -26,7 +26,7 @@ Introduced: v4.0.0
 | `service_name` | String | `haproxy` |  |
 | `config_dir` |  String | `/etc/haproxy` | The directory where the HAProxy configuration resides | Valid directory
 | `config_file` |  String | `/etc/haproxy/haproxy.cfg` | The HAProxy configuration file | Valid file name
-| `systemd_unit` |  String, Hash | See the service resource | A string or hash that contains a systemd unit file definition |
+| `systemd_unit_content` |  String, Hash | See the service resource | A string or hash that contains a systemd unit file definition |
 
 ## Examples
 

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -4,7 +4,7 @@ property :bin_prefix, String, default: '/usr'
 property :config_dir,  String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
 property :service_name, String, default: 'haproxy'
-property :systemd_unit, [String, Hash], default: ''
+property :systemd_unit_content, [String, Hash], default: ''
 
 action :create do
   with_run_context :root do
@@ -16,8 +16,8 @@ action :create do
       mode '0644'
     end
 
-    if new_resource.systemd_unit == ''
-      new_resource.systemd_unit <<-EOU.gsub(/^\s+/, '')
+    if new_resource.systemd_unit_content == ''
+      new_resource.systemd_unit_content <<-EOU.gsub(/^\s+/, '')
 [Unit]
 Description=HAProxy Load Balancer
 Documentation=file:/usr/share/doc/haproxy/configuration.txt.gz
@@ -42,7 +42,7 @@ WantedBy=multi-user.target
     end
 
     systemd_unit "#{new_resource.service_name}.service" do
-      content new_resource.systemd_unit
+      content new_resource.systemd_unit_content
       triggers_reload true
       action [:create, :enable]
       notifies :restart, "service[#{new_resource.service_name}]", :delayed


### PR DESCRIPTION
### Description

Changes the name of the service resource's `systemd_unit` property to `systemd_unit_content`

It conflicts with the `systemd_unit` resource - as one might expect

### Issues Resolved

fixes #378 

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable