### PR TITLE
add haproxy peers as a resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 ## Unreleased
 
-- Add the peer resource 
+- Add the peer resource
 
 ## [v7.1.0] (2019-04-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the haproxy cookbook.
 
+## Unreleased
+
+- Add the peer resource 
+
 ## [v7.1.0] (2019-04-16)
 
 - Clean up unused templates and files

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ listen default
 * [haproxy_frontend](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_frontend.md)
 * [haproxy_install](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_install.md)
 * [haproxy_listen](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_listen.md)
+* [haproxy_peer](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_peer.md)
 * [haproxy_resolver](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_resolver.md)
 * [haproxy_service](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_service.md)
 * [haproxy_use_backend](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_use_backend.md)

--- a/documentation/haproxy_peer.md
+++ b/documentation/haproxy_peer.md
@@ -1,0 +1,60 @@
+[back to resource list](https://github.com/sous-chefs/haproxy#resources)
+
+---
+
+# haproxy_peer
+
+Peer describes a peers resource for haproxy to propogate entries of any data-types in stick-tables between several haproxy instances over TCP connections in a multi-master fashion.
+
+Most of the properties are available only when using HAProxy version >= 2.0. To set properties for versions < 2.0, use the `extra_options` hash. See examples below.
+
+Introduced: v8.0.0
+
+## Actions
+
+`:create`
+
+## Properties
+
+| Name | Type |  Default | Description | Allowed Values
+| -- | -- | -- | -- | -- |
+| `bind` | String, Hash | none | String - sets as given. Hash joins with a space. HAProxy version >= 2.0 |
+| `state` | String, nil | nil | Set the state of the peers | `enabled`, `disabled`, nil
+| `server` | Array | none | Servers in the peer |
+| `default_bind` | String | none | Defines the binding parameters for the local peer, excepted its address |
+| `default_server` | String | none | Change default options for a server |
+| `table` | Array | none | Configure a stickiness table |
+| `extra_options` | Hash | none | Used for setting any HAProxy directives |
+| `config_dir` |  String | `/etc/haproxy` | The directory where the HAProxy configuration resides | Valid directory
+| `config_file` |  String | `/etc/haproxy/haproxy.cfg` | The HAProxy configuration file | Valid file name
+| `config_cookbook` |  String | `haproxy` | Used to configure loading config from another cookbook
+
+## Examples
+
+HAProxy version >= 2.0
+
+```ruby
+haproxy_peer 'mypeers' do
+  bind '0.0.0.0:1336'
+  default_server 'ssl verify none'
+  server ['hostA 127.0.0.10:10000']
+end
+```
+
+```ruby
+haproxy_peer 'mypeers' do
+  bind('0.0.0.0:1336' => 'ssl crt mycerts/pem')
+  default_server 'ssl verify none'
+  server ['hostA 127.0.0.10:10000', 'hostB']
+end
+```
+
+HAProxy version < 2.0
+
+```ruby
+haproxy_peer 'mypeers' do
+  extra_options(
+    'peer' => ['haproxy1 192.168.0.1:1024','haproxy2 192.168.0.2:1024']
+    )
+end
+```

--- a/resources/peer.rb
+++ b/resources/peer.rb
@@ -1,0 +1,38 @@
+property :bind, [ String, Hash ]
+property :state, [ String, nil ], default: nil, equal_to: [ 'enabled', 'disabled', nil ]
+property :server, Array
+property :default_bind, String
+property :default_server, String
+property :table, Array
+property :extra_options, Hash
+property :config_dir, String, default: '/etc/haproxy'
+property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
+property :config_cookbook, String, default: 'haproxy'
+
+action :create do
+  # As we're using the accumulator pattern we need to shove everything
+  # into the root run context so each of the sections can find the parent
+  with_run_context :root do
+    edit_resource(:template, new_resource.config_file) do |new_resource|
+      node.run_state['haproxy'] ||= { 'conf_template_source' => {}, 'conf_cookbook' => {} }
+      source lazy { node.run_state['haproxy']['conf_template_source'][new_resource.config_file] ||= 'haproxy.cfg.erb' }
+      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_cookbook] ||= 'haproxy' }
+      variables['peer'] ||= {}
+      variables['peer'][new_resource.name] ||= {}
+      variables['peer'][new_resource.name]['bind'] ||= {}
+      variables['peer'][new_resource.name]['bind'] = new_resource.bind unless new_resource.bind.nil?
+      variables['peer'][new_resource.name]['state'] = new_resource.state unless new_resource.state.nil?
+      variables['peer'][new_resource.name]['server'] ||= []
+      variables['peer'][new_resource.name]['server'] << new_resource.server unless new_resource.server.nil?
+      variables['peer'][new_resource.name]['default_bind'] = new_resource.default_bind unless new_resource.default_bind.nil?
+      variables['peer'][new_resource.name]['default_server'] = new_resource.default_server unless new_resource.default_server.nil?
+      variables['peer'][new_resource.name]['table'] ||= []
+      variables['peer'][new_resource.name]['table'] << new_resource.table unless new_resource.table.nil?
+      variables['peer'][new_resource.name]['extra_options'] ||= {} unless new_resource.extra_options.nil?
+      variables['peer'][new_resource.name]['extra_options'] = new_resource.extra_options unless new_resource.extra_options.nil?
+
+      action :nothing
+      delayed_action :create
+    end
+  end
+end

--- a/spec/unit/recipes/peer_spec.rb
+++ b/spec/unit/recipes/peer_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe 'haproxy_' do
+  step_into :haproxy_peer, :haproxy_frontend, :haproxy_install, :haproxy_backend
+  platform 'ubuntu'
+
+  context 'create a peers section, frontend and backend and verify config is created properly' do
+    recipe do
+      haproxy_install 'package'
+
+      haproxy_peer 'mypeers' do
+        bind('0.0.0.0:1336' => '')
+        default_server 'ssl verify none'
+        server ['hostA 127.0.0.10:10000']
+      end
+
+      haproxy_frontend 'admin' do
+        bind '0.0.0.0:1337'
+        mode 'http'
+        use_backend ['admin0 if path_beg /admin0']
+      end
+
+      haproxy_backend 'admin' do
+        extra_options('stick-table' => 'type string len 32 size 100k expire 30m peers mypeers')
+        server ['admin0 10.0.0.10:80 check weight 1 maxconn 100']
+      end
+    end
+
+    cfg_content = [
+      'peers mypeers',
+      '  bind 0.0.0.0:1336',
+      '  server hostA 127.0.0.10:10000',
+      '  default-server ssl verify none',
+      '',
+      '',
+      'frontend admin',
+      '  mode http',
+      '  bind 0.0.0.0:1337',
+      '  use_backend admin0 if path_beg /admin0',
+      '',
+      '',
+      'backend admin',
+      '  server admin0 10.0.0.10:80 check weight 1 maxconn 100',
+      '  stick-table type string len 32 size 100k expire 30m peers mypeers',
+    ]
+
+    it { is_expected.to render_file('/etc/haproxy/haproxy.cfg').with_content(/#{cfg_content.join('\n')}/) }
+  end
+end

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -143,6 +143,53 @@ userlist <%= userlist %>
 <% end -%>
 <% end -%>
 <% end -%>
+<% unless @peer.nil? %>
+<% @peer.each do |peer, pv | %>
+
+peers <%= peer %>
+<% if pv['bind'].is_a?(Hash) -%>
+<% pv['bind'].each do |k, v| -%>
+  bind <%= "#{k} #{v}".strip %>
+<% end -%>
+<% else -%>
+  bind <%= pv['bind'] %>
+<% end -%>
+<% unless pv['state'].nil? %>
+  <%= pv['state'] %>
+<% end -%>
+<% unless pv['server'].nil? %>
+<% pv['server'].each do | s |%>
+<% s.each  do |server|%>
+  server <%= server %>
+<% end -%>
+<% end -%>
+<% end -%>
+<% unless pv['default_bind'].nil? %>
+  default-bind <%= pv['default_bind'] %>
+<% end -%>
+<% unless pv['default_server'].nil? %>
+  default-server <%= pv['default_server'] %>
+<% end -%>
+<% unless pv['table'].nil? %>
+<% pv['table'].each do | t |%>
+<% t.each  do |table|%>
+  table <%= table %>
+<% end -%>
+<% end -%>
+<% end -%>
+<% unless pv['extra_options'].nil? %>
+<% pv['extra_options'].each do | key, value |%>
+<% if value.is_a?(Array) %>
+<% value.each do | array_element | %>
+  <%= key %> <%= array_element %>
+<% end -%>
+<% else %>
+  <%= key %> <%= value %>
+<% end -%>
+<% end -%>
+<% end -%>
+<% end # peers loop -%>
+<% end # peers -%>
 <% unless @frontend.nil? %>
 
 <% @frontend.each do |frontend, f | %>


### PR DESCRIPTION
### Description

Adds the HAProxy peers resource 

Support for version 2.0 and less than 2.0 options - see doc examples

https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#3.5

https://cbonte.github.io/haproxy-dconv/1.9/configuration.html#3.5

### Issues Resolved

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable