### PR TITLE
add haproxy mailers as a resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 ## Unreleased
 
 - Add the peer resource
+- Add the mailer resource
 
 ## [v7.1.0] (2019-04-16)
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ listen default
 * [haproxy_frontend](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_frontend.md)
 * [haproxy_install](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_install.md)
 * [haproxy_listen](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_listen.md)
+* [haproxy_mailer](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_mailer.md)
 * [haproxy_peer](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_peer.md)
 * [haproxy_resolver](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_resolver.md)
 * [haproxy_service](https://github.com/sous-chefs/haproxy/tree/master/documentation/haproxy_service.md)

--- a/documentation/haproxy_mailer.md
+++ b/documentation/haproxy_mailer.md
@@ -1,0 +1,39 @@
+[back to resource list](https://github.com/sous-chefs/haproxy#resources)
+
+---
+
+# haproxy_mailer
+
+Mailer describes a mailers resource for sending email alerts on server state changes.
+
+Introduced: v8.0.0
+
+## Actions
+
+`:create`
+
+## Properties
+
+| Name | Type |  Default | Description | Allowed Values
+| -- | -- | -- | -- | -- |
+| `mailer` | String, Array | none | Defines a mailer inside a mailers section |
+| `timeout` | String | none | Defines the time available for a mail/connection to be made and send to the mail-server |
+| `config_dir` |  String | `/etc/haproxy` | The directory where the HAProxy configuration resides | Valid directory
+| `config_file` |  String | `/etc/haproxy/haproxy.cfg` | The HAProxy configuration file | Valid file name
+| `config_cookbook` |  String | `haproxy` | Used to configure loading config from another cookbook
+
+## Examples
+
+```ruby
+haproxy_mailer 'mymailer' do
+  mailer ['smtp1 192.168.0.1:587', 'smtp2 192.168.0.2:587']
+  timeout '20s'
+end
+
+haproxy_backend 'admin' do
+  server ['admin0 10.0.0.10:80 check weight 1 maxconn 100']
+  extra_options('email-alert' => [ 'mailers mymailers',
+                                    'from test1@horms.org',
+                                    'to test2@horms.org' ])
+end
+```

--- a/resources/mailer.rb
+++ b/resources/mailer.rb
@@ -1,0 +1,32 @@
+property :mailer, [String, Array],
+         description: 'Defines a mailer inside a mailers section'
+property :timeout, String,
+         description: 'Defines the time available for a mail/connection to be made and send to the mail-server'
+property :config_dir, String,
+         default: '/etc/haproxy',
+         description: 'The directory where the HAProxy configuration resides'
+property :config_file, String,
+         default: lazy { ::File.join(config_dir, 'haproxy.cfg') },
+         description: 'The HAProxy configuration file'
+property :config_cookbook, String,
+         default: 'haproxy',
+         description: 'Used to configure loading config from another cookbook'
+
+action :create do
+  # As we're using the accumulator pattern we need to shove everything
+  # into the root run context so each of the sections can find the parent
+  with_run_context :root do
+    edit_resource(:template, new_resource.config_file) do |new_resource|
+      node.run_state['haproxy'] ||= { 'conf_template_source' => {}, 'conf_cookbook' => {} }
+      source lazy { node.run_state['haproxy']['conf_template_source'][new_resource.config_file] ||= 'haproxy.cfg.erb' }
+      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_cookbook] ||= 'haproxy' }
+      variables['mailer'] ||= {}
+      variables['mailer'][new_resource.name] ||= {}
+      variables['mailer'][new_resource.name]['mailer'] ||= [new_resource.mailer].flatten unless new_resource.mailer.nil?
+      variables['mailer'][new_resource.name]['timeout'] ||= new_resource.timeout unless new_resource.timeout.nil?
+
+      action :nothing
+      delayed_action :create
+    end
+  end
+end

--- a/spec/unit/recipes/mailer_spec.rb
+++ b/spec/unit/recipes/mailer_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe 'haproxy_' do
+  step_into :haproxy_mailer, :haproxy_frontend, :haproxy_install, :haproxy_backend
+  platform 'ubuntu'
+
+  context 'create a mailer, frontend and backend and verify config is created properly' do
+    recipe do
+      haproxy_install 'package'
+
+      haproxy_mailer 'mymailer' do
+        mailer ['smtp1 192.168.0.1:587', 'smtp2 192.168.0.2:587']
+        timeout '20s'
+      end
+
+      haproxy_frontend 'admin' do
+        bind '0.0.0.0:1337'
+        mode 'http'
+        use_backend ['admin0 if path_beg /admin0']
+      end
+
+      haproxy_backend 'admin' do
+        server ['admin0 10.0.0.10:80 check weight 1 maxconn 100']
+        extra_options('email-alert' => [ 'mailers mymailers',
+                                         'from test1@horms.org',
+                                         'to test2@horms.org' ])
+      end
+    end
+
+    cfg_content = [
+      'mailers mymailer',
+      '  mailer smtp1 192.168.0.1:587',
+      '  mailer smtp2 192.168.0.2:587',
+      '  timeout mail 20s',
+      '',
+      '',
+      'frontend admin',
+      '  mode http',
+      '  bind 0.0.0.0:1337',
+      '  use_backend admin0 if path_beg /admin0',
+      '',
+      '',
+      'backend admin',
+      '  server admin0 10.0.0.10:80 check weight 1 maxconn 100',
+      '  email-alert mailers mymailers',
+      '  email-alert from test1@horms.org',
+      '  email-alert to test2@horms.org',
+    ]
+
+    it { is_expected.to render_file('/etc/haproxy/haproxy.cfg').with_content(/#{cfg_content.join('\n')}/) }
+  end
+end

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -190,6 +190,20 @@ peers <%= peer %>
 <% end -%>
 <% end # peers loop -%>
 <% end # peers -%>
+<% unless @mailer.nil? %>
+<% @mailer.each do |mailer, m | %>
+
+mailers <%= mailer %>
+<% unless m['mailer'].nil? -%>
+<% m['mailer'].each do |mail| -%>
+  mailer <%= mail %>
+<% end -%>
+<% end -%>
+<% unless m['timeout'].nil? %>
+  timeout mail <%= m['timeout'] %>
+<% end -%>
+<% end # mailers loop -%>
+<% end # mailers -%>
 <% unless @frontend.nil? %>
 
 <% @frontend.each do |frontend, f | %>


### PR DESCRIPTION
### Description

Adds the mailers as a resource https://cbonte.github.io/haproxy-dconv/1.9/configuration.html#3.6

Planning to release as part of v8.0.0 with a breaking change that will result from #388 

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable