### PR TITLE
bind hash join with space vs. colon. add missing resource config cookbook property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 ## Unreleased
 
+- The bind config hash joins with a space instead of a colon
 - Add the peer resource
 
 ## [v7.1.0] (2019-04-16)

--- a/documentation/haproxy_acl.md
+++ b/documentation/haproxy_acl.md
@@ -23,6 +23,7 @@ Introduced: v4.2.0
 | `section_name` |  String | none | The name of the specific frontend, listen or backend section |
 | `config_dir` |  String | `/etc/haproxy` | The directory where the HAProxy configuration resides | Valid directory
 | `config_file` |  String | `/etc/haproxy/haproxy.cfg` | The HAProxy configuration file | Valid file name
+| `config_cookbook` |  String | `haproxy` | Used to configure loading config from another cookbook
 
 ## Examples
 

--- a/documentation/haproxy_backend.md
+++ b/documentation/haproxy_backend.md
@@ -27,6 +27,7 @@ Introduced: v4.0.0
 | `hash_type` |  String | none | Specify a method to use for mapping hashes to servers | `consistent`, `map-based`
 | `config_dir` |  String | `/etc/haproxy` | The directory where the HAProxy configuration resides | Valid directory
 | `config_file` |  String | `/etc/haproxy/haproxy.cfg` | The HAProxy configuration file | Valid file name
+| `config_cookbook` |  String | `haproxy` | Used to configure loading config from another cookbook
 
 ## Examples
 

--- a/documentation/haproxy_cache.md
+++ b/documentation/haproxy_cache.md
@@ -22,6 +22,7 @@ Introduced: v6.3.0
 | `max_age` | Integer | none | Define the maximum expiration duration in seconds |
 | `config_dir` |  String | `/etc/haproxy` | The directory where the HAProxy configuration resides | Valid directory
 | `config_file` |  String | `/etc/haproxy/haproxy.cfg` | The HAProxy configuration file | Valid file name
+| `config_cookbook` |  String | `haproxy` | Used to configure loading config from another cookbook
 
 ## Examples
 

--- a/documentation/haproxy_config_defaults.md
+++ b/documentation/haproxy_config_defaults.md
@@ -28,6 +28,7 @@ Introduced: v4.0.0
 | `hash_type` |  String, nil | none | Specify a method to use for mapping hashes to servers | `consistent`, `map-based`, `nil`
 | `config_dir` |  String | `/etc/haproxy` | The directory where the HAProxy configuration resides | Valid directory
 | `config_file` |  String | `/etc/haproxy/haproxy.cfg` | The HAProxy configuration file | Valid file name
+| `config_cookbook` |  String | `haproxy` | Used to configure loading config from another cookbook
 
 ## Examples
 

--- a/documentation/haproxy_config_global.md
+++ b/documentation/haproxy_config_global.md
@@ -30,9 +30,9 @@ Introduced: v4.0.0
 | `log_tag` | String | `haproxy` | Specifies the log tag to use for all outgoing logs |
 | `tuning` | Hash | none | A hash of `tune.<options>` |
 | `extra_options` |  Hash | none | Used for setting any HAProxy directives |
-| `config_cookbook` | String | `haproxy` | Used to configure loading config from another cookbook |
 | `config_dir` |  String | `/etc/haproxy` | The directory where the HAProxy configuration resides | Valid directory
 | `config_file` |  String | `/etc/haproxy/haproxy.cfg` | The HAProxy configuration file | Valid file name
+| `config_cookbook` |  String | `haproxy` | Used to configure loading config from another cookbook
 
 ## Examples
 

--- a/documentation/haproxy_frontend.md
+++ b/documentation/haproxy_frontend.md
@@ -16,7 +16,7 @@ Introduced: v4.0.0
 
 | Name | Type |  Default | Description | Allowed Values
 | -- | -- | -- | -- | -- |
-| `bind` | String, Hash | `0.0.0.0:80` | |
+| `bind` | String, Hash | `0.0.0.0:80` | String - sets as given. Hash joins with a space |
 | `mode` | String | none | Set the running mode or protocol of the instance | `http`, `tcp`
 | `maxconn` | Integer | none | Sets the maximum per-process number of concurrent connections |
 | `reqrep` | String, Array | none | Replace a regular expression with a string in an HTTP request line |
@@ -29,6 +29,7 @@ Introduced: v4.0.0
 | `extra_options` |  Hash | none | Used for setting any HAProxy directives |
 | `config_dir` |  String | `/etc/haproxy` | The directory where the HAProxy configuration resides | Valid directory
 | `config_file` |  String | `/etc/haproxy/haproxy.cfg` | The HAProxy configuration file | Valid file name
+| `config_cookbook` |  String | `haproxy` | Used to configure loading config from another cookbook
 
 ## Examples
 

--- a/documentation/haproxy_listen.md
+++ b/documentation/haproxy_listen.md
@@ -18,7 +18,7 @@ Introduced: v4.0.0
 
 | Name | Type |  Default | Description | Allowed Values
 | -- | -- | -- | -- | -- |
-| `bind` | String, Hash | `0.0.0.0:80` | |
+| `bind` | String, Hash | `0.0.0.0:80` | String - sets as given. Hash joins with a space |
 | `mode` | String | none | Set the running mode or protocol of the instance | `http`, `tcp`
 | `maxconn` | Integer | none | Sets the maximum per-process number of concurrent connections |
 | `reqrep` | String, Array | none | Replace a regular expression with a string in an HTTP request line |
@@ -34,6 +34,7 @@ Introduced: v4.0.0
 | `extra_options` |  Hash | none | Used for setting any HAProxy directives |
 | `config_dir` |  String | `/etc/haproxy` | The directory where the HAProxy configuration resides | Valid directory
 | `config_file` |  String | `/etc/haproxy/haproxy.cfg` | The HAProxy configuration file | Valid file name
+| `config_cookbook` |  String | `haproxy` | Used to configure loading config from another cookbook
 
 ## Examples
 

--- a/documentation/haproxy_resolver.md
+++ b/documentation/haproxy_resolver.md
@@ -22,6 +22,7 @@ Introduced: v4.5.0
 | `extra_options` | Hash | none | Used for setting any HAProxy directives |
 | `config_dir` |  String | `/etc/haproxy` | The directory where the HAProxy configuration resides | Valid directory
 | `config_file` |  String | `/etc/haproxy/haproxy.cfg` | The HAProxy configuration file | Valid file name
+| `config_cookbook` |  String | `haproxy` | Used to configure loading config from another cookbook
 
 ## Examples
 

--- a/documentation/haproxy_use_backend.md
+++ b/documentation/haproxy_use_backend.md
@@ -21,6 +21,7 @@ Introduced: v4.2.0
 | `section_name` |  String | none | The name of the specific frontend, listen or backend section |
 | `config_dir` |  String | `/etc/haproxy` | The directory where the HAProxy configuration resides | Valid directory
 | `config_file` |  String | `/etc/haproxy/haproxy.cfg` | The HAProxy configuration file | Valid file name
+| `config_cookbook` |  String | `haproxy` | Used to configure loading config from another cookbook
 
 ## Examples
 

--- a/documentation/haproxy_userlist.md
+++ b/documentation/haproxy_userlist.md
@@ -20,6 +20,7 @@ Introduced: v4.1.0
 | `user` |  Hash | none | Adds user `<username>` to the current userlist |
 | `config_dir` |  String | `/etc/haproxy` | The directory where the HAProxy configuration resides | Valid directory
 | `config_file` |  String | `/etc/haproxy/haproxy.cfg` | The HAProxy configuration file | Valid file name
+| `config_cookbook` |  String | `haproxy` | Used to configure loading config from another cookbook
 
 ## Examples
 

--- a/resources/acl.rb
+++ b/resources/acl.rb
@@ -3,6 +3,7 @@ property :section, String, required: true, equal_to: %w(frontend listen backend)
 property :section_name, String, required: true
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
+property :config_cookbook, String, default: 'haproxy'
 
 action :create do
   # As we're using the accumulator pattern we need to shove everything
@@ -11,7 +12,7 @@ action :create do
     edit_resource(:template, new_resource.config_file) do |new_resource|
       node.run_state['haproxy'] ||= { 'conf_template_source' => {}, 'conf_cookbook' => {} }
       source lazy { node.run_state['haproxy']['conf_template_source'][new_resource.config_file] ||= 'haproxy.cfg.erb' }
-      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_file] ||= 'haproxy' }
+      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_cookbook] ||= 'haproxy' }
       variables[new_resource.section] ||= {}
       variables[new_resource.section][new_resource.section_name]['acl'] ||= []
       variables[new_resource.section][new_resource.section_name]['acl'] += Array(new_resource.acl)

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -5,10 +5,11 @@ property :reqrep, [Array, String]
 property :reqirep, [Array, String]
 property :acl, Array
 property :option, Array
+property :hash_type, String, equal_to: %w(consistent map-based)
 property :extra_options, Hash
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
-property :hash_type, String, equal_to: %w(consistent map-based)
+property :config_cookbook, String, default: 'haproxy'
 
 action :create do
   # As we're using the accumulator pattern we need to shove everything
@@ -17,7 +18,7 @@ action :create do
     edit_resource(:template, new_resource.config_file) do |new_resource|
       node.run_state['haproxy'] ||= { 'conf_template_source' => {}, 'conf_cookbook' => {} }
       source lazy { node.run_state['haproxy']['conf_template_source'][new_resource.config_file] ||= 'haproxy.cfg.erb' }
-      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_file] ||= 'haproxy' }
+      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_cookbook] ||= 'haproxy' }
       variables['backend'] ||= {}
       variables['backend'][new_resource.name] ||= {}
       variables['backend'][new_resource.name]['mode'] ||= '' unless new_resource.mode.nil?

--- a/resources/cache.rb
+++ b/resources/cache.rb
@@ -4,6 +4,7 @@ property :max_object_size, Integer
 property :max_age, Integer
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
+property :config_cookbook, String, default: 'haproxy'
 
 action :create do
   # As we're using the accumulator pattern we need to shove everything
@@ -12,7 +13,7 @@ action :create do
     edit_resource(:template, new_resource.config_file) do |new_resource|
       node.run_state['haproxy'] ||= { 'conf_template_source' => {}, 'conf_cookbook' => {} }
       source lazy { node.run_state['haproxy']['conf_template_source'][new_resource.config_file] ||= 'haproxy.cfg.erb' }
-      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_file] ||= 'haproxy' }
+      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_cookbook] ||= 'haproxy' }
       variables['cache'] ||= {}
       variables['cache'][new_resource.cache_name] ||= {}
       variables['cache'][new_resource.cache_name]['total_max_size'] ||= new_resource.total_max_size

--- a/resources/config_defaults.rb
+++ b/resources/config_defaults.rb
@@ -5,11 +5,12 @@ property :balance, String, default: 'roundrobin', equal_to: %w(roundrobin static
 property :option, Array, default: %w(httplog dontlognull redispatch tcplog)
 property :stats, Hash, default: { 'uri' => '/haproxy-status' }
 property :maxconn, Integer
+property :hash_type, [String, nil], default: nil, equal_to: ['consistent', 'map-based', nil]
 property :extra_options, Hash
 property :haproxy_retries, Integer
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
-property :hash_type, [String, nil], default: nil, equal_to: ['consistent', 'map-based', nil]
+property :config_cookbook, String, default: 'haproxy'
 
 action :create do
   # As we're using the accumulator pattern we need to shove everything
@@ -18,7 +19,7 @@ action :create do
     edit_resource(:template, new_resource.config_file) do |new_resource|
       node.run_state['haproxy'] ||= { 'conf_template_source' => {}, 'conf_cookbook' => {} }
       source lazy { node.run_state['haproxy']['conf_template_source'][new_resource.config_file] ||= 'haproxy.cfg.erb' }
-      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_file] ||= 'haproxy' }
+      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_cookbook] ||= 'haproxy' }
       variables['defaults'] ||= {}
       variables['defaults']['timeout'] ||= {}
       variables['defaults']['timeout'] = new_resource.timeout unless new_resource.timeout.nil?

--- a/resources/config_global.rb
+++ b/resources/config_global.rb
@@ -11,13 +11,13 @@ property :stats, Hash, default: lazy {
   }
 }
 property :maxconn, Integer, default: 4096
-property :config_cookbook, String, default: 'haproxy'
 property :chroot, String
 property :log_tag, String, default: 'haproxy'
 property :tuning, Hash
 property :extra_options, Hash
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
+property :config_cookbook, String, default: 'haproxy'
 
 action :create do
   node.default['haproxy']['user'] = new_resource.haproxy_user

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,10 +1,10 @@
 property :install_type, String, name_property: true, equal_to: %w(package source)
 property :conf_template_source, String, default: 'haproxy.cfg.erb'
-property :conf_cookbook, String, default: 'haproxy'
 property :conf_file_mode, String, default: '0644'
 property :bin_prefix, String, default: '/usr'
 property :config_dir,  String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
+property :config_cookbook, String, default: 'haproxy'
 property :haproxy_user, String, default: 'haproxy'
 property :haproxy_group, String, default: 'haproxy'
 property :sensitive, [true, false], default: true
@@ -42,7 +42,7 @@ property :use_systemd,      String, equal_to: %w(0 1), default: lazy { source_ve
 action :create do
   node.run_state['haproxy'] ||= { 'conf_template_source' => {}, 'conf_cookbook' => {} }
   node.run_state['haproxy']['conf_template_source'][new_resource.config_file] = new_resource.conf_template_source
-  node.run_state['haproxy']['conf_cookbook'][new_resource.config_file] = new_resource.conf_cookbook
+  node.run_state['haproxy']['conf_cookbook'][new_resource.config_file] = new_resource.config_cookbook
 
   case new_resource.install_type
   when 'package'

--- a/resources/resolver.rb
+++ b/resources/resolver.rb
@@ -2,6 +2,7 @@ property :nameserver, Array
 property :extra_options, Hash
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
+property :config_cookbook, String, default: 'haproxy'
 
 action :create do
   # As we're using the accumulator pattern we need to shove everything
@@ -10,7 +11,7 @@ action :create do
     edit_resource(:template, new_resource.config_file) do |new_resource|
       node.run_state['haproxy'] ||= { 'conf_template_source' => {}, 'conf_cookbook' => {} }
       source lazy { node.run_state['haproxy']['conf_template_source'][new_resource.config_file] ||= 'haproxy.cfg.erb' }
-      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_file] ||= 'haproxy' }
+      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_cookbook] ||= 'haproxy' }
       variables['resolvers'] ||= {}
       variables['resolvers'][new_resource.name] ||= {}
       variables['resolvers'][new_resource.name]['nameserver'] ||= [] unless new_resource.nameserver.nil?

--- a/resources/use_backend.rb
+++ b/resources/use_backend.rb
@@ -3,6 +3,7 @@ property :section, String, required: true, equal_to: %w(frontend listen backend)
 property :section_name, String, required: true
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
+property :config_cookbook, String, default: 'haproxy'
 
 action :create do
   # As we're using the accumulator pattern we need to shove everything
@@ -11,7 +12,7 @@ action :create do
     edit_resource(:template, new_resource.config_file) do |new_resource|
       node.run_state['haproxy'] ||= { 'conf_template_source' => {}, 'conf_cookbook' => {} }
       source lazy { node.run_state['haproxy']['conf_template_source'][new_resource.config_file] ||= 'haproxy.cfg.erb' }
-      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_file] ||= 'haproxy' }
+      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_cookbook] ||= 'haproxy' }
       variables[new_resource.section] ||= {}
       variables[new_resource.section][new_resource.section_name]['use_backend'] ||= []
       variables[new_resource.section][new_resource.section_name]['use_backend'] += Array(new_resource.use_backend)

--- a/resources/userlist.rb
+++ b/resources/userlist.rb
@@ -2,6 +2,7 @@ property :group, Hash
 property :user, Hash
 property :config_dir, String, default: '/etc/haproxy'
 property :config_file, String, default: lazy { ::File.join(config_dir, 'haproxy.cfg') }
+property :config_cookbook, String, default: 'haproxy'
 
 action :create do
   # As we're using the accumulator pattern we need to shove everything
@@ -10,7 +11,7 @@ action :create do
     edit_resource(:template, new_resource.config_file) do |new_resource|
       node.run_state['haproxy'] ||= { 'conf_template_source' => {}, 'conf_cookbook' => {} }
       source lazy { node.run_state['haproxy']['conf_template_source'][new_resource.config_file] ||= 'haproxy.cfg.erb' }
-      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_file] ||= 'haproxy' }
+      cookbook lazy { node.run_state['haproxy']['conf_cookbook'][new_resource.config_cookbook] ||= 'haproxy' }
       variables['userlist'] ||= {}
       variables['userlist'][new_resource.name] ||= {}
       variables['userlist'][new_resource.name]['group'] ||= []

--- a/spec/unit/recipes/frontend_backend_spec.rb
+++ b/spec/unit/recipes/frontend_backend_spec.rb
@@ -9,7 +9,7 @@ describe 'haproxy_' do
       haproxy_install 'package'
 
       haproxy_frontend 'admin' do
-        bind '0.0.0.0:1337'
+        bind '0.0.0.0:1337' => ''
         mode 'http'
         use_backend ['admin0 if path_beg /admin0']
         extra_options('http-request' => 'add-header Test Value')

--- a/test/fixtures/cookbooks/test/recipes/config_1.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_1.rb
@@ -61,8 +61,9 @@ haproxy_frontend 'multi-reqirep' do
 end
 
 haproxy_frontend 'multiport' do
-  bind '*' => '8080',
-       '0.0.0.0' => %w(8081 8180)
+  bind '*:8080' => '',
+       '0.0.0.0:8081' => '',
+       '0.0.0.0:8080' => ''
   default_backend 'servers'
 end
 

--- a/test/fixtures/cookbooks/test/recipes/config_1.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_1.rb
@@ -63,7 +63,7 @@ end
 haproxy_frontend 'multiport' do
   bind '*:8080' => '',
        '0.0.0.0:8081' => '',
-       '0.0.0.0:8080' => ''
+       '0.0.0.0:8180' => ''
   default_backend 'servers'
 end
 

--- a/test/fixtures/cookbooks/test/recipes/config_3.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_3.rb
@@ -34,8 +34,9 @@ haproxy_frontend 'tcp-in' do
 end
 
 haproxy_frontend 'multiport' do
-  bind '*' => '8080',
-       '0.0.0.0' => %w(8081 8180)
+  bind '*:8080' => '',
+       '0.0.0.0:8081' => '',
+       '0.0.0.0:8080' => ''
   default_backend 'servers'
 end
 

--- a/test/fixtures/cookbooks/test/recipes/config_3.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_3.rb
@@ -36,7 +36,7 @@ end
 haproxy_frontend 'multiport' do
   bind '*:8080' => '',
        '0.0.0.0:8081' => '',
-       '0.0.0.0:8080' => ''
+       '0.0.0.0:8180' => ''
   default_backend 'servers'
 end
 

--- a/test/fixtures/cookbooks/test/recipes/config_array.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_array.rb
@@ -38,7 +38,7 @@ haproxy_frontend 'tcp-in' do
   default_backend 'tcp-servers'
 end
 
-bind_hash = { '*' => '8080', '0.0.0.0' => %w(8081 8180) }
+bind_hash = { '*:8080' => '', '0.0.0.0:8081' => '', '0.0.0.0:8080' => '' }
 
 haproxy_frontend 'multiport' do
   bind bind_hash

--- a/test/fixtures/cookbooks/test/recipes/config_custom_template.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_custom_template.rb
@@ -3,7 +3,7 @@ apt_update
 
 haproxy_install 'package' do
   conf_template_source 'custom-template.cfg.erb'
-  conf_cookbook 'test'
+  config_cookbook 'test'
 end
 
 directory '/var/lib/haproxy' do


### PR DESCRIPTION
### Description

The `bind` property when set as a hash, joins using a space instead of a colon.

Adds the missing `config_cookbook` property to all resources and docs

### Issues Resolved

Resolves #388 - the `bind` property when set as a hash, joins using a space instead of a colon.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable