### PR TITLE
The bind config hash joins with a space instead of a colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 ## Unreleased
 
+- The bind config hash joins with a space instead of a colon
 - Add the peer resource
 
 ## [v7.1.0] (2019-04-16)

--- a/documentation/haproxy_frontend.md
+++ b/documentation/haproxy_frontend.md
@@ -16,7 +16,7 @@ Introduced: v4.0.0
 
 | Name | Type |  Default | Description | Allowed Values
 | -- | -- | -- | -- | -- |
-| `bind` | String, Hash | `0.0.0.0:80` | |
+| `bind` | String, Hash | `0.0.0.0:80` | String - sets as given. Hash joins with a space |
 | `mode` | String | none | Set the running mode or protocol of the instance | `http`, `tcp`
 | `maxconn` | Integer | none | Sets the maximum per-process number of concurrent connections |
 | `reqrep` | String, Array | none | Replace a regular expression with a string in an HTTP request line |

--- a/documentation/haproxy_listen.md
+++ b/documentation/haproxy_listen.md
@@ -18,7 +18,7 @@ Introduced: v4.0.0
 
 | Name | Type |  Default | Description | Allowed Values
 | -- | -- | -- | -- | -- |
-| `bind` | String, Hash | `0.0.0.0:80` | |
+| `bind` | String, Hash | `0.0.0.0:80` | String - sets as given. Hash joins with a space |
 | `mode` | String | none | Set the running mode or protocol of the instance | `http`, `tcp`
 | `maxconn` | Integer | none | Sets the maximum per-process number of concurrent connections |
 | `reqrep` | String, Array | none | Replace a regular expression with a string in an HTTP request line |

--- a/resources/frontend.rb
+++ b/resources/frontend.rb
@@ -28,7 +28,7 @@ action :create do
       if new_resource.bind.is_a? Hash
         new_resource.bind.map do |addresses, ports|
           (Array(addresses).product Array(ports)).each do |combo|
-            variables['frontend'][new_resource.name]['bind'] << combo.join(':')
+            variables['frontend'][new_resource.name]['bind'] << combo.join(' ').strip
           end
         end
       else

--- a/resources/listen.rb
+++ b/resources/listen.rb
@@ -31,7 +31,7 @@ action :create do
       if new_resource.bind.is_a? Hash
         new_resource.bind.map do |addresses, ports|
           (Array(addresses).product Array(ports)).each do |combo|
-            variables['listen'][new_resource.name]['bind'] << combo.join(':')
+            variables['listen'][new_resource.name]['bind'] << combo.join(' ').strip
           end
         end
       else

--- a/spec/unit/recipes/frontend_backend_spec.rb
+++ b/spec/unit/recipes/frontend_backend_spec.rb
@@ -9,7 +9,7 @@ describe 'haproxy_' do
       haproxy_install 'package'
 
       haproxy_frontend 'admin' do
-        bind '0.0.0.0:1337'
+        bind '0.0.0.0:1337' => ''
         mode 'http'
         use_backend ['admin0 if path_beg /admin0']
         extra_options('http-request' => 'add-header Test Value')

--- a/spec/unit/recipes/listen_spec.rb
+++ b/spec/unit/recipes/listen_spec.rb
@@ -9,7 +9,7 @@ describe 'haproxy_listen' do
       haproxy_install 'package'
 
       haproxy_listen 'admin' do
-        bind '0.0.0.0:1337'
+        bind '0.0.0.0:1337' => ''
         mode 'http'
         stats uri: '/',
               realm: 'Haproxy-Statistics',

--- a/test/fixtures/cookbooks/test/recipes/config_1.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_1.rb
@@ -62,7 +62,8 @@ end
 
 haproxy_frontend 'multiport' do
   bind '*' => '8080',
-       '0.0.0.0' => %w(8081 8180)
+       '0.0.0.0:8081' => '',
+       '0.0.0.0:8180' => ''
   default_backend 'servers'
 end
 

--- a/test/fixtures/cookbooks/test/recipes/config_1.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_1.rb
@@ -61,7 +61,7 @@ haproxy_frontend 'multi-reqirep' do
 end
 
 haproxy_frontend 'multiport' do
-  bind '*' => '8080',
+  bind '*:8080' => '',
        '0.0.0.0:8081' => '',
        '0.0.0.0:8180' => ''
   default_backend 'servers'

--- a/test/fixtures/cookbooks/test/recipes/config_3.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_3.rb
@@ -34,7 +34,7 @@ haproxy_frontend 'tcp-in' do
 end
 
 haproxy_frontend 'multiport' do
-  bind '*' => '8080',
+  bind '*:8080' => '',
        '0.0.0.0:8081' => '',
        '0.0.0.0:8180' => ''
   default_backend 'servers'

--- a/test/fixtures/cookbooks/test/recipes/config_3.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_3.rb
@@ -35,7 +35,8 @@ end
 
 haproxy_frontend 'multiport' do
   bind '*' => '8080',
-       '0.0.0.0' => %w(8081 8180)
+       '0.0.0.0:8081' => '',
+       '0.0.0.0:8180' => ''
   default_backend 'servers'
 end
 

--- a/test/fixtures/cookbooks/test/recipes/config_array.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_array.rb
@@ -38,7 +38,7 @@ haproxy_frontend 'tcp-in' do
   default_backend 'tcp-servers'
 end
 
-bind_hash = { '*' => '8080', '0.0.0.0' => %w(8081 8180) }
+bind_hash = { '*:8080' => '', '0.0.0.0:8081' => '', '0.0.0.0:8080' => '' }
 
 haproxy_frontend 'multiport' do
   bind bind_hash

--- a/test/fixtures/cookbooks/test/recipes/config_array.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_array.rb
@@ -38,7 +38,7 @@ haproxy_frontend 'tcp-in' do
   default_backend 'tcp-servers'
 end
 
-bind_hash = { '*:8080' => '', '0.0.0.0:8081' => '', '0.0.0.0:8080' => '' }
+bind_hash = { '*:8080' => '', '0.0.0.0:8081' => '', '0.0.0.0:8180' => '' }
 
 haproxy_frontend 'multiport' do
   bind bind_hash


### PR DESCRIPTION
### Description

The bind property when set as a hash, joins using a space instead of a colon.
### Issues Resolved

Resolves #388 - the bind property when set as a hash, joins using a space instead of a colon.
### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable