### PR TITLE
replace linux2628 with linux-glibc for haproxy 2.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the haproxy cookbook.
 
+## UNRELEASED
+
+- Updated build target to linux-glibc for haproxy 2.0 compatibility
+
 ## [v8.0.0] (2019-05-29)
 
 - The bind config hash joins with a space instead of a colon

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -22,9 +22,9 @@ property :source_target_cpu, [String, nil], default: lazy { node['kernel']['mach
 property :source_target_arch, [String, nil], default: nil
 property :source_target_os, String, default: lazy {
   if node['kernel']['release'].split('.')[0..1].join('.').to_f > 2.6
-    @target_os = 'linux2628'
+    @target_os = 'linux-glibc'
   elsif (node['kernel']['release'].split('.')[0..1].join('.').to_f > 2.6) && (node['kernel']['release'].split('.')[2].split('-').first.to_i > 28)
-    @target_os = 'linux2628'
+    @target_os = 'linux-glibc'
   elsif (node['kernel']['release'].split('.')[0..1].join('.').to_f > 2.6) && (node['kernel']['release'].split('.')[2].split('-').first.to_i < 28)
     @target_os = 'linux26'
   else


### PR DESCRIPTION
### Description

For Haproxy 2.0 compatibility, replace linux2628 with linux-glibc

### Issues Resolved

When attempting to compile from source with this cookbook:

STDOUT: Target 'linux2628' was removed from HAProxy 2.0 due to being irrelevant and
often wrong. Please use 'linux-glibc' instead or define your custom target

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable