### PR TITLE
Update metadata.rb chef_version to >=13.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the haproxy cookbook.
 
+## Unreleased
+
+- Update metadata.rb chef_version to >=13.9 due to resource `description`
+
 ## [v8.1.0] (2019-06-24)
 
 - Updated build target to linux-glibc for haproxy 2.0 compatibility

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 ## Requirements
 
 * HAProxy `stable` or `LTS`
-* Chef 13+
+* Chef 13.9+
 
 ### Platforms
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           '8.1.0'
 source_url        'https://github.com/sous-chefs/haproxy'
 issues_url        'https://github.com/sous-chefs/haproxy/issues'
-chef_version      '>= 13.0'
+chef_version      '>= 13.9'
 
 supports 'debian'
 supports 'ubuntu'


### PR DESCRIPTION
### Description

Updates the metadata.rb chef_version to >=13.9 due to resource `description` field which is not supported in early versions of chef

### Issues Resolved

Reported in https://github.com/sous-chefs/haproxy/issues/401

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable