### PR TITLE
Update config_defaults resource stats default value to empty hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 This file is used to list changes made in each version of the haproxy cookbook.
 
-## Unreleased
+## [v8.1.1] (2019-10-02)
 
+- Update `config_defaults` resource `stats` property default value to empty hash
 - Update metadata.rb chef_version to >=13.9 due to resource `description`
 
 ## [v8.1.0] (2019-06-24)

--- a/documentation/haproxy_config_defaults.md
+++ b/documentation/haproxy_config_defaults.md
@@ -20,7 +20,7 @@ Introduced: v4.0.0
 | `log` | String | `global` | Enable per-instance logging of events and traffic |
 | `mode` |  String | `http` | Set the running mode or protocol of the instance | `http`, `tcp`
 | `balance` | String | `roundrobin` | Define the load balancing algorithm to be used in a backend | `roundrobin static-rr`, `leastconn`, `first`, `source`, `uri`, `url_param`, `header`, `rdp-cookie`
-| `stats` | Hash | `{ 'uri' => '/haproxy-status' }` | Enable HAProxy statistics |
+| `stats` | Hash | `{}` | Enable HAProxy statistics |
 | `maxconn` | Integer | none | Sets the maximum per-process number of concurrent connections |
 | `haproxy_retries` | Integer | none | Set the number of retries to perform on a server after a connection failure |
 | `option` |  Array | `['httplog', 'dontlognull', 'redispatch', 'tcplog']` | Array of HAProxy `option` directives |

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures haproxy'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '8.1.0'
+version           '8.1.1'
 source_url        'https://github.com/sous-chefs/haproxy'
 issues_url        'https://github.com/sous-chefs/haproxy/issues'
 chef_version      '>= 13.9'

--- a/resources/config_defaults.rb
+++ b/resources/config_defaults.rb
@@ -3,7 +3,7 @@ property :log, String, default: 'global'
 property :mode, String, default: 'http', equal_to: %w(http tcp health)
 property :balance, String, default: 'roundrobin', equal_to: %w(roundrobin static-rr leastconn first source uri url_param header rdp-cookie)
 property :option, Array, default: %w(httplog dontlognull redispatch tcplog)
-property :stats, Hash, default: { 'uri' => '/haproxy-status' }
+property :stats, Hash, default: {}
 property :maxconn, Integer
 property :extra_options, Hash
 property :haproxy_retries, Integer

--- a/test/integration/config_1/example_spec.rb
+++ b/test/integration/config_1/example_spec.rb
@@ -40,7 +40,6 @@ describe file('/etc/haproxy/haproxy.cfg') do
     '  option redispatch',
     '  option tcplog',
     '  retries 5',
-    '  stats uri /haproxy-status',
     '',
     '',
     'frontend http-in',

--- a/test/integration/config_1_userlist/example_spec.rb
+++ b/test/integration/config_1_userlist/example_spec.rb
@@ -36,7 +36,6 @@ cfg_content = [
   '  option redispatch',
   '  option tcplog',
   '  retries 5',
-  '  stats uri /haproxy-status',
   '',
   '',
   'userlist mylist',

--- a/test/integration/config_2/example_spec.rb
+++ b/test/integration/config_2/example_spec.rb
@@ -32,7 +32,6 @@ cfg_content = [
   '  option dontlognull',
   '  option redispatch',
   '  option tcplog',
-  '  stats uri /haproxy-status',
   '',
   '',
   'frontend http',

--- a/test/integration/config_3/example_spec.rb
+++ b/test/integration/config_3/example_spec.rb
@@ -37,7 +37,6 @@ cfg_content = [
   '  option redispatch',
   '  option tcplog',
   '  retries 5',
-  '  stats uri /haproxy-status',
   '',
   '',
   'frontend http-in',

--- a/test/integration/config_4/example_spec.rb
+++ b/test/integration/config_4/example_spec.rb
@@ -37,7 +37,6 @@ describe file('/etc/haproxy/haproxy.cfg') do
     '  option dontlognull',
     '  option redispatch',
     '  option tcplog',
-    '  stats uri /haproxy-status',
     '',
     '',
     'backend servers',

--- a/test/integration/config_acl/example_spec.rb
+++ b/test/integration/config_acl/example_spec.rb
@@ -25,7 +25,6 @@ describe file('/etc/haproxy/haproxy.cfg') do
     '  option dontlognull',
     '  option redispatch',
     '  option tcplog',
-    '  stats uri /haproxy-status',
   ]
   its('content') { should match(/#{defaults.join('\n')}/) }
   # Frontend http

--- a/test/integration/config_array/example_spec.rb
+++ b/test/integration/config_array/example_spec.rb
@@ -36,7 +36,6 @@ cfg_content = [
   '  option redispatch',
   '  option tcplog',
   '  retries 5',
-  '  stats uri /haproxy-status',
   '',
   '',
   'frontend http-in',

--- a/test/integration/config_backend_search/example_spec.rb
+++ b/test/integration/config_backend_search/example_spec.rb
@@ -35,7 +35,6 @@ cfg_content = [
   '  option dontlognull',
   '  option redispatch',
   '  option tcplog',
-  '  stats uri /haproxy-status',
   '',
   '',
   'frontend http-in',

--- a/test/integration/config_resolver/example_spec.rb
+++ b/test/integration/config_resolver/example_spec.rb
@@ -35,7 +35,6 @@ cfg_content = [
   '  option dontlognull',
   '  option redispatch',
   '  option tcplog',
-  '  stats uri /haproxy-status',
 ]
 
 describe file('/etc/haproxy/haproxy.cfg') do

--- a/test/integration/config_ssl_redirect/example_spec.rb
+++ b/test/integration/config_ssl_redirect/example_spec.rb
@@ -37,7 +37,6 @@ cfg_content = [
   '  option redispatch',
   '  option tcplog',
   '  retries 5',
-  '  stats uri /haproxy-status',
   '',
   '',
   'frontend http-in',


### PR DESCRIPTION
### Description

Sets the default value for `stats` in `config_defaults.rb` to an empty hash. Users creating the uri stats endpoint will likely want to add authentication and will not want a default open stats page.

### Issues Resolved

closes: #403 

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable