### PR TITLE
Run latest cookstyle

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,6 @@ maintainer        'Sous Chefs'
 maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures haproxy'
-
 version           '8.1.1'
 source_url        'https://github.com/sous-chefs/haproxy'
 issues_url        'https://github.com/sous-chefs/haproxy/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Sous Chefs'
 maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures haproxy'
-long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+
 version           '8.1.1'
 source_url        'https://github.com/sous-chefs/haproxy'
 issues_url        'https://github.com/sous-chefs/haproxy/issues'

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -2,7 +2,7 @@
 name              'test'
 maintainer        'Heavy Water Software Inc.'
 maintainer_email  'ops@hw-ops.com'
-license           'Apache 2.0'
+license           'Apache-2.0'
 description       'Testing cookbook for haproxy'
 version           '0.0.1'
 depends           'haproxy'


### PR DESCRIPTION
### Description

Run the latest cookstyle

### Issues Resolved

```
→ cookstyle -a
Inspecting 58 files
..R...............................R.......................

Offenses:

metadata.rb:6:1: R: [Corrected] ChefDeprecations/LongDescriptionMetadata: The long_description metadata.rb method is not used and is unnecessary in cookbooks
long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/fixtures/cookbooks/test/metadata.rb:5:19: R: [Corrected] ChefCorrectness/InvalidLicenseString: Cookbook metadata.rb does not use a SPDX compliant license string or "all rights reserved". See https://spdx.org/licenses/ for a complete list of license identifiers.
license           'Apache 2.0'
                  ^^^^^^^^^^^^

58 files inspected, 2 offenses detected, 2 offenses corrected


```

### Contribution checklist
- [x] All tests pass