### PR TITLE
add lua installation flags

### DIFF
--- a/documentation/haproxy_install.md
+++ b/documentation/haproxy_install.md
@@ -44,6 +44,10 @@ Introduced: v4.0.0
 | `use_linux_tproxy`     | String      | `1`                                                              |                                                                                | `0`, `1`            |
 | `use_linux_splice`     | String      | `1`                                                              |                                                                                | `0`, `1`            |
 | `use_systemd`     | String      | `1`                                                              |                                                                                | `0`, `1`            |
+| `use_lua`              | String      | `0`                                     | `0`, `1`            |
+| `lua_lib`              | String, nil | `nil`                                   | |
+| `lua_inc`              | String, nil | `nil`                                   | |
+
 
 ## Examples
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -40,6 +40,10 @@ suites:
   - name: source-default
     run_list:
       - recipe[test::source]
+  - name: source_lua
+    run_list:
+      - recipe[test::source_lua]
+    includes: centos-7
   - name: config_1
     run_list:
       - recipe[test::config_1]

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -30,6 +30,9 @@ property :use_openssl,        String, equal_to: %w(0 1), default: '1'
 property :use_zlib,           String, equal_to: %w(0 1), default: '1'
 property :use_linux_tproxy,   String, equal_to: %w(0 1), default: '1'
 property :use_linux_splice,   String, equal_to: %w(0 1), default: '1'
+property :use_lua,            String, equal_to: %w(0 1), default: '0'
+property :lua_lib,            [String, nil]
+property :lua_inc,            [String, nil]
 property :use_systemd,        String, equal_to: %w(0 1), default: lazy { source_version.to_f >= 1.8 ? '1' : '0' }
 
 unified_mode true
@@ -84,6 +87,9 @@ action :create do
     make_cmd << " USE_LINUX_TPROXY=#{new_resource.use_linux_tproxy}"
     make_cmd << " USE_LINUX_SPLICE=#{new_resource.use_linux_splice}"
     make_cmd << " USE_SYSTEMD=#{new_resource.use_systemd}"
+    make_cmd << " USE_LUA=#{new_resource.use_lua}"
+    make_cmd << " LUA_LIB=#{new_resource.lua_lib}" unless new_resource.lua_lib.nil?
+    make_cmd << " LUA_INC=#{new_resource.lua_inc}" unless new_resource.lua_inc.nil?
     extra_cmd = ' EXTRA=haproxy-systemd-wrapper' if new_resource.source_version.to_f < 1.8
 
     bash 'compile_haproxy' do

--- a/test/fixtures/cookbooks/test/recipes/source_lua.rb
+++ b/test/fixtures/cookbooks/test/recipes/source_lua.rb
@@ -1,0 +1,50 @@
+execute 'dev tools' do
+  command 'yum group install -y "Development Tools"'
+  action :run
+end
+
+package %w(readline-devel)
+
+# download lua
+remote_file "#{Chef::Config[:file_cache_path]}/lua-5.3.1.tar.gz" do
+  source 'http://lua.org/ftp/lua-5.3.1.tar.gz'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  action :create
+  not_if { ::File.exist?('/opt/lua-5.3.1/bin/lua') }
+end
+
+# extract lua
+execute 'lua extract' do
+  command 'tar xf lua-5.3.1.tar.gz'
+  cwd "#{Chef::Config[:file_cache_path]}"
+  not_if { ::File.exist?('/opt/lua-5.3.1/bin/lua') }
+end
+
+# compile lua
+execute 'lua compile' do
+  command 'make linux'
+  cwd "#{Chef::Config[:file_cache_path]}/lua-5.3.1"
+  not_if { ::File.exist?('/opt/lua-5.3.1/bin/lua') }
+end
+
+execute 'lua install' do
+  command 'make INSTALL_TOP=/opt/lua-5.3.1 install'
+  cwd "#{Chef::Config[:file_cache_path]}/lua-5.3.1"
+  not_if { ::File.exist?('/opt/lua-5.3.1/bin/lua') }
+end
+
+haproxy_install 'source' do
+  source_url 'http://www.haproxy.org/download/2.0/src/haproxy-2.0.5.tar.gz'
+  source_checksum '3f2e0d40af66dd6df1dc2f6055d3de106ba62836d77b4c2e497a82a4bdbc5422'
+  source_version '2.0.5'
+  use_pcre '1'
+  use_openssl '1'
+  use_zlib '1'
+  use_linux_tproxy '1'
+  use_linux_splice '1'
+  use_lua '1'
+  lua_lib '/opt/lua-5.3.1/lib'
+  lua_inc '/opt/lua-5.3.1/include'
+end

--- a/test/integration/source_lua/lua_spec.rb
+++ b/test/integration/source_lua/lua_spec.rb
@@ -1,0 +1,7 @@
+describe directory '/opt/lua-5.3.1' do
+  it { should exist }
+end
+
+describe command('haproxy -vv | grep Lua') do
+  its('stdout') { should match /Built with Lua version/ }
+end


### PR DESCRIPTION
### Description

Adds lua flags to `haproxy_install` resource. Haproxy can be built with lua (http://www.haproxy.org/download/2.0/doc/lua.txt)

```
HAProxy builds with your favourite options, plus the following options for
embedding the Lua script language:
...
 - build HAProxy:
   make TARGET=linux-glibc \
        USE_LUA=1 \
        LUA_LIB=/opt/lua-5.3.1/lib \
        LUA_INC=/opt/lua-5.3.1/include
```

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable