### PR TITLE
Fix app versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
           - "centos-stream-8"
         suite:
           - "package"
+          - "source-18"
           - "source-20"
-          - "source-21"
           - "source-default"
       fail-fast: false
 


### PR DESCRIPTION
### Description

We were testing HAProxy app version 2.1 when we only have suites for 1.8 and 2.0

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable