### PR TITLE
Adding Prom Exporter compile time install flag 

### DIFF
--- a/documentation/haproxy_install.md
+++ b/documentation/haproxy_install.md
@@ -17,38 +17,39 @@ Introduced: v4.0.0
 
 This resource also uses the following partial resources:
 
-* [_config_file](https://github.com/sous-chefs/haproxy/tree/master/documentation/partial_config_file.md)
+* [\_config_file](https://github.com/sous-chefs/haproxy/tree/master/documentation/partial_config_file.md)
 
-| Name                 | Type        | Default                                                          | Description                                                                    | Allowed Values      |
-| -------------------- | ----------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------- |
-| `install_type`       | String      | None                                                             | Set the installation type                                                      | `package`, `source` |
-| `bin_prefix`         | String      | `/usr`                                                           | Set the source compile prefix                                                  |
-| `sensitive`          | Boolean     | `true`                                                           | Ensure that sensitive resource data is not logged by the chef-client           |
-| `use_systemd`        | Boolean     | `true`                                                           | Evalues whether to use systemd based on the nodes init package                 |
-| `user`               | String      | `haproxy`                                                        | Similar to "uid" but uses the UID of user name `<user name>` from /etc/passwd  |
-| `group`              | String      | `haproxy`                                                        | Similar to "gid" but uses the GID of group name `<group name>` from /etc/group |
-| `package_name`       | String      | `haproxy`                                                        |                                                                                |
-| `package_version`    | String      |                                                                  |                                                                                |
-| `enable_ius_repo`    | Boolean     | `false`                                                          | Enables the IUS package repo for Centos to install versions >1.5               |
-| `enable_epel_repo`   | Boolean     | `true`                                                           | Enables the epel repo for RHEL based operating systems                         |
-| `source_version`     | String      | `2.2.4`                                                          |                                                                                |
-| `source_url`         | String      | `http://www.haproxy.org/download/2.2.4/src/haproxy-2.2.4.tar.gz` |                                                                                |
-| `source_checksum`    | String      |                                                                  |                                                                                |
-| `source_target_cpu`  | String      | `node['kernel']['machine']`                                      |                                                                                |
-| `source_target_arch` | String      |                                                                  |                                                                                |
-| `source_target_os`   | String      | See resource                                                     |                                                                                |
-| `use_libcrypt`       | Boolean     | `true`                                                           |                                                                                | `true`, `false`     |
-| `use_pcre`           | Boolean     | `true`                                                           |                                                                                | `true`, `false`     |
-| `use_openssl`        | Boolean     | `true`                                                           | Include openssl support (https://openssl.org)                                  | `true`, `false`     |
-| `use_zlib`           | Boolean     | `true`                                                           | Include ZLIB support                                                           | `true`, `false`     |
-| `use_linux_tproxy`   | Boolean     | `true`                                                           |                                                                                | `true`, `false`     |
-| `use_linux_splice`   | Boolean     | `true`                                                           |                                                                                | `true`, `false`     |
-| `use_systemd`        | Boolean     | `true`                                                           |                                                                                | `true`, `false`     |
-| `use_lua`            | Boolean     | `false`                                                          | Include Lua support                                                            | `true`, `false`     |
-| `lua_lib`            | String      |                                                                  | Path for lua library files ex: `/opt/lib-5.3.5/lib`                            |
-| `lua_inc`            | String      |                                                                  | Path for lua library files ex: `/opt/lib-5.3.5/include`                        |
-| `ssl_lib`            | String      |                                                                  | Path for openssl library files ex: `/usr/local/openssl/lib`                    |
-| `ssl_inc`            | String      |                                                                  | Path for openssl includes files ex: `/usr/local/openssl/inc`                   |
+| Name                 | Type    | Default                                                          | Description                                                                    | Allowed Values      |
+| -------------------- | ------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------- |
+| `install_type`       | String  | None                                                             | Set the installation type                                                      | `package`, `source` |
+| `bin_prefix`         | String  | `/usr`                                                           | Set the source compile prefix                                                  |
+| `sensitive`          | Boolean | `true`                                                           | Ensure that sensitive resource data is not logged by the chef-client           |
+| `use_systemd`        | Boolean | `true`                                                           | Evalues whether to use systemd based on the nodes init package                 |
+| `user`               | String  | `haproxy`                                                        | Similar to "uid" but uses the UID of user name `<user name>` from /etc/passwd  |
+| `group`              | String  | `haproxy`                                                        | Similar to "gid" but uses the GID of group name `<group name>` from /etc/group |
+| `package_name`       | String  | `haproxy`                                                        |                                                                                |
+| `package_version`    | String  |                                                                  |                                                                                |
+| `enable_ius_repo`    | Boolean | `false`                                                          | Enables the IUS package repo for Centos to install versions >1.5               |
+| `enable_epel_repo`   | Boolean | `true`                                                           | Enables the epel repo for RHEL based operating systems                         |
+| `source_version`     | String  | `2.2.4`                                                          |                                                                                |
+| `source_url`         | String  | `http://www.haproxy.org/download/2.2.4/src/haproxy-2.2.4.tar.gz` |                                                                                |
+| `source_checksum`    | String  |                                                                  |                                                                                |
+| `source_target_cpu`  | String  | `node['kernel']['machine']`                                      |                                                                                |
+| `source_target_arch` | String  |                                                                  |                                                                                |
+| `source_target_os`   | String  | See resource                                                     |                                                                                |
+| `use_libcrypt`       | Boolean | `true`                                                           |                                                                                | `true`, `false`     |
+| `use_pcre`           | Boolean | `true`                                                           |                                                                                | `true`, `false`     |
+| `use_openssl`        | Boolean | `true`                                                           | Include openssl support (https://openssl.org)                                  | `true`, `false`     |
+| `use_zlib`           | Boolean | `true`                                                           | Include ZLIB support                                                           | `true`, `false`     |
+| `use_linux_tproxy`   | Boolean | `true`                                                           |                                                                                | `true`, `false`     |
+| `use_linux_splice`   | Boolean | `true`                                                           |                                                                                | `true`, `false`     |
+| `use_promex`         | Boolean | `false`                                                          | Enable the included Prometheus exporter (HAProxy v2.4+)                             | `true`, `false`     |
+| `use_systemd`        | Boolean | `true`                                                           |                                                                                | `true`, `false`     |
+| `use_lua`            | Boolean | `false`                                                          | Include Lua support                                                            | `true`, `false`     |
+| `lua_lib`            | String  |                                                                  | Path for lua library files ex: `/opt/lib-5.3.5/lib`                            |
+| `lua_inc`            | String  |                                                                  | Path for lua library files ex: `/opt/lib-5.3.5/include`                        |
+| `ssl_lib`            | String  |                                                                  | Path for openssl library files ex: `/usr/local/openssl/lib`                    |
+| `ssl_inc`            | String  |                                                                  | Path for openssl includes files ex: `/usr/local/openssl/inc`                   |
 
 ## Examples
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -38,6 +38,9 @@ suites:
   - name: source-2.2
     run_list:
       - recipe[test::source-22]
+  - name: source-2.4
+    run_list:
+      - recipe[test::source-24]    
   - name: source-default
     run_list:
       - recipe[test::source]

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -53,6 +53,9 @@ property :use_libcrypt, [true, false],
 property :use_pcre, [true, false],
           default: true
 
+property :use_promex, [true, false],
+          default: false
+
 property :use_openssl, [true, false],
           default: true
 
@@ -150,6 +153,7 @@ action :install do
     make_cmd << " USE_LINUX_SPLICE=#{compile_make_boolean(new_resource.use_linux_splice)}"
     make_cmd << " USE_SYSTEMD=#{compile_make_boolean(new_resource.use_systemd)}"
     make_cmd << " USE_LUA=#{compile_make_boolean(new_resource.use_lua)}" if new_resource.use_lua
+    make_cmd << " USE_PROMEX=#{compile_make_boolean(new_resource.use_promex)}" if new_resource.use_promex
     make_cmd << " LUA_LIB=#{new_resource.lua_lib}" if property_is_set?(:lua_lib)
     make_cmd << " LUA_INC=#{new_resource.lua_inc}" if property_is_set?(:lua_inc)
     make_cmd << " SSL_LIB=#{new_resource.ssl_lib}" if property_is_set?(:ssl_lib)

--- a/test/cookbooks/test/recipes/source-24.rb
+++ b/test/cookbooks/test/recipes/source-24.rb
@@ -1,0 +1,23 @@
+apt_update
+
+haproxy_install 'source' do
+  source_url 'http://www.haproxy.org/download/2.4/src/haproxy-2.4.0.tar.gz'
+  source_checksum '0a6962adaf5a1291db87e3eb4ddf906a72fed535dbd2255b164b7d8394a53640'
+  source_version '2.4.0'
+  use_libcrypt true
+  use_pcre true
+  use_openssl true
+  use_zlib true
+  use_promex true
+  use_linux_tproxy true
+  use_linux_splice true
+end
+
+haproxy_config_global ''
+
+haproxy_config_defaults ''
+
+haproxy_service 'haproxy' do
+  action :create
+  delayed_action %i(enable start)
+end

--- a/test/integration/source-2.4/source_spec.rb
+++ b/test/integration/source-2.4/source_spec.rb
@@ -1,0 +1,17 @@
+describe directory '/etc/haproxy' do
+  it { should exist }
+end
+
+describe file '/etc/haproxy/haproxy.cfg' do
+  its(:mode) { should cmp '0640' }
+end
+
+describe service 'haproxy' do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe command('haproxy -vv') do
+  its('stdout') { should match /Built with the Prometheus exporter as a service/ }
+end


### PR DESCRIPTION
# Description

HAProxy 2.4 adds a Makefile argument to enable the HAProxy built-in Prometheus exporter. Previously this was a multi-step process. Only works in HAProxy versions 2.4+

## Issues Resolved

None

## Check List

- [] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
