### PR TITLE
Add option property to haproxy_listen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the haproxy cookbook.
 
 ## Unreleased
 
+- Add `option` property to `haproxy_listen` - [@eheydrick](https://github.com/eheydrick)
+
 ## 12.2.2 - *2021-10-05*
 
 ## 12.2.1 - *2021-08-30*

--- a/documentation/haproxy_listen.md
+++ b/documentation/haproxy_listen.md
@@ -37,6 +37,7 @@ This resource also uses the following partial resources:
 | `server`          | Array         | None         | Servers the listen section routes to                                     |
 | `stats`           | Hash          | None         | Enable stats with various options                                        |
 | `hash_type`       | String        | None         | Specify a method to use for mapping hashes to servers                    | `consistent`, `map-based`  |
+| `option`          | Array         | None         | Array of HAProxy `option` directives                                     |
 
 ## Examples
 

--- a/resources/listen.rb
+++ b/resources/listen.rb
@@ -39,6 +39,9 @@ property :use_backend, Array,
 property :acl, Array,
           description: 'Access control list items'
 
+property :option, Array,
+          description: 'Array of HAProxy option directives'
+
 property :server, Array,
           description: 'Servers the listen section routes to'
 
@@ -93,6 +96,11 @@ action :create do
   if property_is_set?(:server)
     haproxy_config_resource.variables['listen'][new_resource.name]['server'] ||= []
     haproxy_config_resource.variables['listen'][new_resource.name]['server'].push(new_resource.server)
+  end
+
+  if property_is_set?(:option)
+    haproxy_config_resource.variables['listen'][new_resource.name]['option'] ||= []
+    haproxy_config_resource.variables['listen'][new_resource.name]['option'].push(new_resource.option)
   end
 
   haproxy_config_resource.variables['listen'][new_resource.name]['hash_type'] = new_resource.hash_type if property_is_set?(:hash_type)

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -419,6 +419,13 @@ listen <%= key %>
 <% if listen['default_backend'] -%>
   default_backend <%= listen['default_backend'] %>
 <% end %>
+<% unless nil_or_empty?(listen['option']) %>
+<% listen['option'].each do | option |%>
+<% option.each do | option | %>
+  option <%= option %>
+<% end -%>
+<% end -%>
+<% end -%>
 <% unless nil_or_empty?(listen['extra_options']) %>
 <% listen['extra_options'].each do | key, value | %>
 <% if key == 'http-request' %>

--- a/test/cookbooks/test/recipes/config_4.rb
+++ b/test/cookbooks/test/recipes/config_4.rb
@@ -20,6 +20,7 @@ haproxy_listen 'admin' do
   ]
   http_response 'set-header Expires %[date(3600),http_date]'
   default_backend 'servers'
+  option ['dontlog-normal']
   extra_options('bind-process' => 'odd')
   hash_type 'consistent'
 end

--- a/test/integration/config_4/example_spec.rb
+++ b/test/integration/config_4/example_spec.rb
@@ -71,6 +71,7 @@ describe file('/etc/haproxy/haproxy.cfg') do
     '  http-request add-header X-Proto http',
     '  http-response set-header Expires %\[date\(3600\),http_date\]',
     '  default_backend servers',
+    '  option dontlog-normal',
     '  bind-process odd',
     '  hash-type consistent',
     '',


### PR DESCRIPTION
Signed-off-by: Eric Heydrick <eheydrick@gmail.com>

# Description

Add `option` property to `haproxy_listen` like the frontend and backend resources already have.

## Issues Resolved

#469 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
