### PR TITLE
fix: repair workflow actionlint failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,6 @@ jobs:
           - "config-resolver"
           - "config-ssl-redirect"
           - "config-custom-template"
-          - "config-custom-template"
           - "config-array"
           - "config-fastcgi"
       fail-fast: false


### PR DESCRIPTION
## Summary

* Fix GitHub Actions workflow syntax/static lint failures reported by actionlint.
* Remove invalid debug output, stale matrix entries, duplicate matrix values, or conflict markers as applicable.

## Verification

* `actionlint -no-color -oneline`
* `yq e '.' .github/workflows/*.yml`
