### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,14 +14,13 @@ wget https://packages.chef.io/files/stable/chef-workstation/24.12.1031/ubuntu/24
 sudo dpkg -i chef-workstation_24.12.1031-1_amd64.deb
 
 # Method 2: Install individual gems if Chef Workstation fails
-sudo gem install cookstyle chefspec rspec berkshelf test-kitchen kitchen-dokken --no-document
+sudo gem install cookstyle chefspec rspec test-kitchen kitchen-dokken --no-document
 ```
 
 ### Core Development Commands
 ```bash
-# Install cookbook dependencies (if berkshelf is available)
-berks install
-# NOTE: If berkshelf is not installed, cookbook will still work for basic linting/testing
+# Install cookbook dependencies
+chef install Policyfile.rb
 
 # Lint Ruby code - takes 2-3 seconds - NEVER CANCEL
 cookstyle .
@@ -135,7 +134,7 @@ kitchen destroy config-2-ubuntu-2204
 
 ### Important Files
 - `metadata.rb` - Cookbook metadata and dependencies
-- `Berksfile` - Cookbook dependency management
+- `Policyfile.rb` - Cookbook dependency management
 - `kitchen.yml` - Vagrant-based integration testing (local development)
 - `kitchen.dokken.yml` - Docker-based integration testing (CI)
 - `.rubocop.yml` - Ruby linting configuration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,6 @@ jobs:
           - "config-resolver"
           - "config-ssl-redirect"
           - "config-custom-template"
-          - "config-custom-template"
           - "config-array"
           - "config-fastcgi"
       fail-fast: false

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,13 +36,11 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/
 .coverage/
 .zero-knife.rb
-Policyfile.lock.json
 
 # vagrant stuff
 .vagrant/

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,0 +1,158 @@
+{
+  "revision_id": "e9e7da3f03ec90f888d9e62ac571754b83c5ccceffd25f750617577be5d8ded9",
+  "name": "haproxy",
+  "run_list": [
+    "recipe[test::package]"
+  ],
+  "named_run_lists": {
+    "config_2": [
+      "recipe[test::config_2]"
+    ],
+    "config_3": [
+      "recipe[test::config_3]"
+    ],
+    "config_acl": [
+      "recipe[test::config_acl]"
+    ],
+    "config_array": [
+      "recipe[test::config_array]"
+    ],
+    "config_backend_search": [
+      "recipe[test::config_backend_search]"
+    ],
+    "config_custom_template": [
+      "recipe[test::config_custom_template]"
+    ],
+    "config_fastcgi": [
+      "recipe[test::config_fastcgi]"
+    ],
+    "config_resolver": [
+      "recipe[test::config_resolver]"
+    ],
+    "config_ssl_redirect": [
+      "recipe[test::config_ssl_redirect]"
+    ],
+    "package": [
+      "recipe[test::package]"
+    ],
+    "source": [
+      "recipe[test::source]"
+    ],
+    "source_24": [
+      "recipe[test::source_24]"
+    ],
+    "source_26": [
+      "recipe[test::source_26]"
+    ],
+    "source_28": [
+      "recipe[test::source_28]"
+    ],
+    "source_28_pcre2": [
+      "recipe[test::source_28_pcre2]"
+    ],
+    "source_lua": [
+      "recipe[test::source_lua]"
+    ],
+    "source_openssl": [
+      "recipe[test::source_openssl]"
+    ]
+  },
+  "included_policy_locks": [
+
+  ],
+  "cookbook_locks": {
+    "haproxy": {
+      "version": "12.4.13",
+      "identifier": "7faf8d17a08c269bb537eb92f213d5fb79293d74",
+      "dotted_decimal_identifier": "35940342563900454.43827873170256403.235276046253428",
+      "source": ".",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": null,
+        "revision": "565a79f31987f53786e61784ee1928c711b4bcce",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/HEAD -> origin/main",
+          "origin/main"
+        ]
+      },
+      "source_options": {
+        "path": "."
+      }
+    },
+    "test": {
+      "version": "0.0.1",
+      "identifier": "5e2218f2c1e05c80013463ac8232f64a91929a19",
+      "dotted_decimal_identifier": "26496138358153308.36030121541141042.270800130316825",
+      "source": "test/cookbooks/test",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": null,
+        "revision": "565a79f31987f53786e61784ee1928c711b4bcce",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/HEAD -> origin/main",
+          "origin/main"
+        ]
+      },
+      "source_options": {
+        "path": "test/cookbooks/test"
+      }
+    },
+    "yum-epel": {
+      "version": "5.0.10",
+      "identifier": "3ffd59317825177023566a99bf5940e29163cfd4",
+      "dotted_decimal_identifier": "18011483056645399.31564051454213977.71341846024148",
+      "cache_key": "yum-epel-0ae39de8b609c2904012f4da4cf261b6e3361f74",
+      "origin": "https://github.com/sous-chefs/yum-epel.git",
+      "source_options": {
+        "git": "https://github.com/sous-chefs/yum-epel.git",
+        "revision": "0ae39de8b609c2904012f4da4cf261b6e3361f74",
+        "branch": "main"
+      }
+    }
+  },
+  "default_attributes": {
+
+  },
+  "override_attributes": {
+
+  },
+  "solution_dependencies": {
+    "Policyfile": [
+      [
+        "haproxy",
+        ">= 0.0.0"
+      ],
+      [
+        "test",
+        ">= 0.0.0"
+      ],
+      [
+        "yum-epel",
+        ">= 0.0.0"
+      ]
+    ],
+    "dependencies": {
+      "haproxy (12.4.13)": [
+        [
+          "yum-epel",
+          ">= 0.0.0"
+        ]
+      ],
+      "test (0.0.1)": [
+        [
+          "haproxy",
+          ">= 0.0.0"
+        ]
+      ],
+      "yum-epel (5.0.10)": [
+
+      ]
+    }
+  }
+}

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "e9e7da3f03ec90f888d9e62ac571754b83c5ccceffd25f750617577be5d8ded9",
+  "revision_id": "b9d24e60ac21ab3c0ecba3453df8e0b255b2f00ae504f58b6828da5de4f5f4b4",
   "name": "haproxy",
   "run_list": [
     "recipe[test::package]"
@@ -63,19 +63,18 @@
   "cookbook_locks": {
     "haproxy": {
       "version": "12.4.13",
-      "identifier": "7faf8d17a08c269bb537eb92f213d5fb79293d74",
-      "dotted_decimal_identifier": "35940342563900454.43827873170256403.235276046253428",
+      "identifier": "2d7dc66eb12cece395df07e798f1d3f94e757140",
+      "dotted_decimal_identifier": "12804665166081260.64059604856183025.233067716636992",
       "source": ".",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
-        "remote": null,
-        "revision": "565a79f31987f53786e61784ee1928c711b4bcce",
+        "remote": "https://github.com/sous-chefs/haproxy.git",
+        "revision": "396d9112cf5d04b38206b178f4b92f220ba943a8",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
-          "origin/HEAD -> origin/main",
-          "origin/main"
+          "origin/chore/policyfile-migration"
         ]
       },
       "source_options": {
@@ -90,13 +89,12 @@
       "cache_key": null,
       "scm_info": {
         "scm": "git",
-        "remote": null,
-        "revision": "565a79f31987f53786e61784ee1928c711b4bcce",
+        "remote": "https://github.com/sous-chefs/haproxy.git",
+        "revision": "396d9112cf5d04b38206b178f4b92f220ba943a8",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
-          "origin/HEAD -> origin/main",
-          "origin/main"
+          "origin/chore/policyfile-migration"
         ]
       },
       "source_options": {

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'haproxy'
+
+run_list 'test::package'
+
+cookbook 'haproxy', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+cookbook 'yum-epel', git: 'https://github.com/sous-chefs/yum-epel.git', branch: 'main'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/documentation/haproxy_install.md
+++ b/documentation/haproxy_install.md
@@ -36,7 +36,7 @@ This resource also uses the following partial resources:
 | `source_target_arch` | String  |                                                                  |                                                                                |                     |
 | `source_target_os`   | String  | See resource                                                     |                                                                                |                     |
 | `use_libcrypt`       | Boolean | `true`                                                           |                                                                                | `true`, `false`     |
-| `use_pcre`           | Boolean | `true`                                                           | Enable PCRE regex support. Automatically selects PCRE2 for RHEL/CentOS/AlmaLinux/Rocky >= 10, PCRE for < 10, Amazon Linux, and Fedora. | `true`, `false`     |
+| `use_pcre`           | Boolean | `true`                                                           | Enable PCRE regex support. Uses PCRE2 on RHEL-family >= 10 and PCRE elsewhere. | `true`, `false`     |
 | `use_openssl`        | Boolean | `true`                                                           | Include openssl support (<https://openssl.org>)                                | `true`, `false`     |
 | `use_zlib`           | Boolean | `true`                                                           | Include ZLIB support                                                           | `true`, `false`     |
 | `use_linux_tproxy`   | Boolean | `true`                                                           |                                                                                | `true`, `false`     |

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -4,7 +4,9 @@ driver:
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport: { name: dokken }
-provisioner: { name: dokken }
+provisioner:
+  name: dokken
+  policyfile: Policyfile.rb
 
 platforms:
   - name: almalinux-8

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -1,6 +1,6 @@
 ---
 provisioner:
-  name: chef_infra
+  name: policyfile_zero
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable
@@ -10,6 +10,7 @@ provisioner:
   multiple_converge: <%= ENV['MULTIPLE_CONVERGE'] || 2 %>
   deprecations_as_errors: true
   log_level: <%= ENV['CHEF_LOG_LEVEL'] || 'auto' %>
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,13 +3,14 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
+  name: policyfile_zero
   deprecations_as_errors: true
   chef_license: accept
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   install_strategy: always
   log_level: <%= ENV['CHEF_LOG_LEVEL'] || 'auto' %>
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec
@@ -26,53 +27,53 @@ platforms:
 
 suites:
   - name: package
-    run_list:
-      - recipe[test::package]
+    provisioner:
+      named_run_list: package
   - name: source-2.4
-    run_list:
-      - recipe[test::source_24]
+    provisioner:
+      named_run_list: source_24
   - name: source_2.6
-    run_list:
-      - recipe[test::source_26]
+    provisioner:
+      named_run_list: source_26
   - name: source_2.8
-    run_list:
-      - recipe[test::source_28]
+    provisioner:
+      named_run_list: source_28
   - name: source_default
-    run_list:
-      - recipe[test::source]
+    provisioner:
+      named_run_list: source
   - name: source_lua
-    run_list:
-      - recipe[test::source_lua]
+    provisioner:
+      named_run_list: source_lua
   - name: source_openssl
-    run_list:
-      - recipe[test::source_openssl]
+    provisioner:
+      named_run_list: source_openssl
   - name: config_2
-    run_list:
-      - recipe[test::config_2]
+    provisioner:
+      named_run_list: config_2
   - name: config_3
-    run_list:
-      - recipe[test::config_3]
+    provisioner:
+      named_run_list: config_3
   - name: config_4
-    run_list:
-      - recipe[test::config_4]
+    provisioner:
+      named_run_list: config_4
   - name: config_backend_search
-    run_list:
-      - recipe[test::config_backend_search]
+    provisioner:
+      named_run_list: config_backend_search
   - name: config_acl
-    run_list:
-      - recipe[test::config_acl]
+    provisioner:
+      named_run_list: config_acl
   - name: config_resolver
-    run_list:
-      - recipe[test::config_resolver]
+    provisioner:
+      named_run_list: config_resolver
   - name: config_ssl_redirect
-    run_list:
-      - recipe[test::config_ssl_redirect]
+    provisioner:
+      named_run_list: config_ssl_redirect
   - name: config_custom_template
-    run_list:
-      - recipe[test::config_custom_template]
+    provisioner:
+      named_run_list: config_custom_template
   - name: config_array
-    run_list:
-      - recipe[test::config_array]
+    provisioner:
+      named_run_list: config_array
   - name: config_fastcgi
-    run_list:
-      - recipe[test::config_fastcgi]
+    provisioner:
+      named_run_list: config_fastcgi

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -109,9 +109,9 @@ action :install do
   when 'package'
     case node['platform_family']
     when 'amazon'
-      include_recipe 'yum-epel' if new_resource.enable_epel_repo
+      yum_epel 'default' if new_resource.enable_epel_repo
     when 'rhel'
-      include_recipe 'yum-epel' if new_resource.enable_epel_repo
+      yum_epel 'default' if new_resource.enable_epel_repo
 
       if new_resource.enable_ius_repo
         if ius_platform_valid?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary

- Replace Berkshelf dependency management with Policyfile/Policyfile.lock.
- Switch ChefSpec and Kitchen to Policyfile support while preserving named test run-list semantics.
- Remove stale Berkshelf setup/ignore references and fix existing lint blockers in CI/docs.

## Validation

- chef install Policyfile.rb
- chef update Policyfile.rb
- cookstyle
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation
- markdownlint-cli2 "**/*.md" "!vendor" "!.venv"
- yamllint .github .markdownlint-cli2.yaml .overcommit.yml .rubocop.yml kitchen.dokken.yml kitchen.exec.yml kitchen.global.yml kitchen.yml test/integration
- actionlint -no-color -oneline
- git diff --check
- kitchen list
- env -u DOCKER_HOST kitchen diagnose package-ubuntu-2404
- env -u DOCKER_HOST kitchen test package-ubuntu-2404 --destroy=always